### PR TITLE
Cambios aplicado a componente [ExportButtons] redondeo a 2 decimales …

### DIFF
--- a/src/app/inicio/empleador/cuentaCorriente/components/ExportButtons.tsx
+++ b/src/app/inicio/empleador/cuentaCorriente/components/ExportButtons.tsx
@@ -25,6 +25,8 @@ const ExportButtons: React.FC<ExportButtonsProps> = ({ data, type, sumarleUnMesA
             ...row,
             periodoCobertura: Formato.Fecha(sumarleUnMesAlPeriodo?.(row.periodo), "MM-YYYY"),
             periodoDDJJ: Formato.Fecha(row.periodo, "MM-YYYY"),
+            saldo: row.saldo != null ? parseFloat(row.saldo.toFixed(2)) : row.saldo,
+            saldoAcumulado: row.saldoAcumulado != null ? parseFloat(row.saldoAcumulado.toFixed(2)) : row.saldoAcumulado,
         }));
         
         const exportColumns = {
@@ -61,6 +63,8 @@ const ExportButtons: React.FC<ExportButtonsProps> = ({ data, type, sumarleUnMesA
             ...row,
             periodoCobertura: Formato.Fecha(sumarleUnMesAlPeriodo?.(row.periodo), "MM-YYYY"),
             periodoDDJJ: Formato.Fecha(row.periodo, "MM-YYYY"),
+            saldo: row.saldo != null ? parseFloat(row.saldo.toFixed(2)) : row.saldo,
+            saldoAcumulado: row.saldoAcumulado != null ? parseFloat(row.saldoAcumulado.toFixed(2)) : row.saldoAcumulado,
         }));
         
         const exportColumns = {


### PR DESCRIPTION
Problema: Los archivos CSV exportaban los saldos con más de 2 decimales.

Solución: Se agregó redondeo a 2 decimales para los campos [saldo] y [saldoAcumulado] antes de exportar.

Resultado: Ahora los saldos se exportan con exactamente 2 decimales en CSV y Excel.

Card de trello: https://trello.com/c/ktu4URR8/152-art-ruraltemaartgestion-gestion-empleador-ctactefecha04-12-2025