### PR TITLE
Fix: nombre se autocompleta con nombre + apellido desde ARCA

### DIFF
--- a/src/app/inicio/comercializador/administracionComercializadores/formulario/DatosUsuarioSection.tsx
+++ b/src/app/inicio/comercializador/administracionComercializadores/formulario/DatosUsuarioSection.tsx
@@ -78,7 +78,7 @@ export default function DatosUsuarioSection({
 
       <div className={styles.formRow}>
         <TextField
-          label="Nombre"
+          label="Nombre/Apellido"
           name="nombre"
           value={form.nombre}
           onChange={onTextFieldChange}

--- a/src/app/inicio/comercializador/administracionComercializadores/formulario/UsuarioForm.tsx
+++ b/src/app/inicio/comercializador/administracionComercializadores/formulario/UsuarioForm.tsx
@@ -230,6 +230,16 @@ export default function UsuarioForm({
     { revalidateOnFocus: false, revalidateOnReconnect: false }
   );
 
+  useEffect(() => {
+    if (!arcaData) return;
+    setForm(prev => ({
+      ...prev,
+      nombre: ([arcaData.nombre, arcaData.apellido].filter(Boolean).join(' ')) || prev.nombre,
+      apellido: arcaData.apellido ?? prev.apellido,
+      fechaNacimiento: arcaData.fechaNacimiento ? dayjs(arcaData.fechaNacimiento).format('DD/MM/YYYY') : prev.fechaNacimiento,
+    }));
+  }, [arcaData]);
+
   let localidadesOptions: any[] = [];
   if (nombreBuscado) {
     localidadesOptions = Array.isArray(localidadesByNombre) ? localidadesByNombre : [];

--- a/src/app/inicio/usuarios/UsuarioForm.tsx
+++ b/src/app/inicio/usuarios/UsuarioForm.tsx
@@ -617,7 +617,8 @@ export default function UsuarioForm({
     if (!arcaData) return;
     setForm(prev => ({
       ...prev,
-      nombre: arcaData.nombre ?? prev.nombre,
+      nombre: ([arcaData.nombre, arcaData.apellido].filter(Boolean).join(' ')) || prev.nombre,
+      apellido: arcaData.apellido ?? prev.apellido,
       fechaNacimiento: arcaData.fechaNacimiento ? dayjs(arcaData.fechaNacimiento).format('DD/MM/YYYY') : prev.fechaNacimiento,
     }));
   }, [arcaData]);
@@ -1111,11 +1112,13 @@ export default function UsuarioForm({
                   ) : arcaData ? (
                     <ul className={styles.infoList}>
                       <li><strong>Nombre:</strong> {arcaData.nombre || ''}</li>
+                      <li><strong>Apellido:</strong> {arcaData.apellido || ''}</li>
                       <li><strong>Fecha de Nac.:</strong> {arcaData.fechaNacimiento ? dayjs(arcaData.fechaNacimiento).format('DD/MM/YYYY') : ''}</li>
                     </ul>
                   ) : (
                     <ul className={styles.infoList}>
                       <li><strong>Nombre:</strong> </li>
+                      <li><strong>Apellido:</strong> </li>
                       <li><strong>Fecha de Nac.:</strong> </li>
                     </ul>
                   )}


### PR DESCRIPTION
Actualizo:

Se realizaron las modificaciones para:

Creación de usuarios:

En la información de ARCA aparece el apellido.

Nombre/apellido se autocompleta con apellido + nombre de lo que devuelve ARCA

Creación desde la administración de Comercializador.

Nombre/apellido se autocompleta con apellido + nombre de lo que devuelve ARCA