### PR TITLE
Feat: Buscador por cuil trabajador Formulario RAR

### DIFF
--- a/src/app/inicio/empleador/formularioRAR/FormulariosRAR.module.css
+++ b/src/app/inicio/empleador/formularioRAR/FormulariosRAR.module.css
@@ -58,6 +58,9 @@
 /* Contenedor de tabla con título */
 .tableBlock { margin-top: 60px; width: 100%; }
 
+/* Buscador por CUIL en tabla de trabajadores */
+.buscadorCuil { margin-bottom: 12px; }
+
 /* Compactar tabla (antes estaba en <style jsx>) */
 .compactTable :global(table) {
   font-size: 12px;

--- a/src/app/inicio/empleador/formularioRAR/editar/FormularioRAREditor.tsx
+++ b/src/app/inicio/empleador/formularioRAR/editar/FormularioRAREditor.tsx
@@ -79,6 +79,9 @@ const FormulariosRAREditar: React.FC<EditarProps> = ({ edita, finalizaCarga }) =
   const [editandoIndex, setEditandoIndex] = React.useState<number>(-1);
   const [modoEdicion, setModoEdicion] = React.useState<boolean>(false);
 
+  // Filtro por CUIL en la tabla de trabajadores cargados
+  const [filtroCuil, setFiltroCuil] = React.useState<string>('');
+
   // CARGA INICIAL
   React.useEffect(() => {
     (async () => {
@@ -476,9 +479,18 @@ const FormulariosRAREditar: React.FC<EditarProps> = ({ edita, finalizaCarga }) =
       {filas.length > 0 && (
         <div className={styles.tableBlock}>
           <span className={`${styles.bold} ${styles.fs20}`}>Datos del Trabajador:</span>
+          <div className={styles.buscadorCuil}>
+            <TextField
+              label="Buscador por CUIL"
+              value={filtroCuil}
+              onChange={(e) => setFiltroCuil(e.target.value)}
+              size="small"
+              placeholder="Ingresá el CUIL a buscar..."
+            />
+          </div>
           <DataTableImport
             columns={[
-              { accessorKey: 'CUIL', header: 'CUIL' },
+              { accessorKey: 'CUIL', header: 'CUIL', cell: ({ getValue }: { getValue: () => string }) => Formato.CUIP(getValue()) },
               { accessorKey: 'Nombre', header: 'Nombre' },
               { accessorKey: 'SectorTareas', header: 'Sector/Tareas' },
               { accessorKey: 'Ingreso', header: 'F. Ingreso', cell: ({ getValue }: any) => formatoFechaTabla(getValue()) },
@@ -521,7 +533,7 @@ const FormulariosRAREditar: React.FC<EditarProps> = ({ edita, finalizaCarga }) =
                 enableSorting: false,
               },
             ]}
-            data={filas}
+            data={filtroCuil ? filas.filter(f => (f.CUIL || '').replace(/\D/g, '').startsWith(filtroCuil.replace(/\D/g, ''))) : filas}
           />
         </div>
       )}

--- a/src/app/inicio/empleador/formularioRAR/generar/FormularioRARGenerar.module.css
+++ b/src/app/inicio/empleador/formularioRAR/generar/FormularioRARGenerar.module.css
@@ -197,6 +197,11 @@
   font-style: italic;
 }
 
+/* Buscador por CUIL en tabla de trabajadores */
+.buscadorCuil {
+  margin-bottom: 12px;
+}
+
 /* Contenedor de acciones en fila */
 .accionesContainer {
   display: flex;

--- a/src/app/inicio/empleador/formularioRAR/generar/FormularioRARGenerar.tsx
+++ b/src/app/inicio/empleador/formularioRAR/generar/FormularioRARGenerar.tsx
@@ -128,6 +128,9 @@ const FormularioRARCrear: React.FC<CrearProps> = ({
     // Estado para mostrar errores
   const [mensajeError, setMensajeError] = React.useState<string>('');
 
+  // Filtro por CUIL en la tabla de trabajadores cargados
+  const [filtroCuil, setFiltroCuil] = React.useState<string>('');
+
   const guardandoRef = React.useRef(false);
 
   // ===== Funciones para manejo de trabajadores =====
@@ -160,7 +163,7 @@ const FormularioRARCrear: React.FC<CrearProps> = ({
   // ===== Configuración de columnas para DataTable =====
   const columnasTabla = React.useMemo(() => [
     {
-      accessorKey: 'CUIL',
+      accessorKey: 'CUILDisplay',
       header: 'CUIL',
       size: 120,
     },
@@ -269,12 +272,17 @@ const FormularioRARCrear: React.FC<CrearProps> = ({
   const filasTabla = React.useMemo(() => {
     return filas.map((f) => ({
       ...f,
+      CUILDisplay: f.CUIL ? Formato.CUIP(f.CUIL) : '',
       IngresoDisplay: f.Ingreso ? Formato.Fecha(f.Ingreso, 'DD/MM/YYYY') : '',
       FechaInicioDisplay: f.FechaInicio ? Formato.Fecha(f.FechaInicio, 'DD/MM/YYYY') : '',
       FechaFinExposicionDisplay: f.FechaFinExposicion ? Formato.Fecha(f.FechaFinExposicion, 'DD/MM/YYYY') : '',
       UltimoExamenMedicoDisplay: f.UltimoExamenMedico ? Formato.Fecha(f.UltimoExamenMedico, 'DD/MM/YYYY') : '',
     }));
   }, [filas]);
+
+  const filasTablaFiltradas = filtroCuil
+    ? filasTabla.filter(f => normalizarCuil(f.CUIL).startsWith(normalizarCuil(filtroCuil)))
+    : filasTabla;
 
   // ===== Helpers =====
   const numerosValidos = (v: string) => {
@@ -576,6 +584,7 @@ React.useEffect(() => {
         }
 
         // Agentes
+        try {
         const respAg = await fetch('http://arttest.intersistemas.ar:8302/api/AgentesCausantes');
         const agentes = respAg.ok ? await respAg.json() : [];
         const agArr = Array.isArray(agentes)
@@ -596,10 +605,12 @@ React.useEffect(() => {
 
         if (!cancel) setAgentesCausantes(opcionesAgentes);
       } catch (e) {
-        console.error('Error cargando selects:', e);
+        console.error('Error cargando agentes causantes:', e);
+        }
+      } catch (e) {
+        console.error('Error cargando establecimientos:', e);
         if (!cancel) {
           setOpcionesEstablecimientos([]);
-          setAgentesCausantes([]);
         }
       } finally {
         if (!cancel) setCargandoSelects(false);
@@ -1810,12 +1821,19 @@ React.useEffect(() => {
           {/* TABLA DE TRABAJADORES CARGADOS */}
           {filas.length > 0 && (
             <div className={styles.tablaTrabajadoresContainer}>
-              <h4 className={styles.tablaTrabajadoresTitle}>
-                Trabajadores Cargados
-              </h4>
+
+              <div className={styles.buscadorCuil}>
+                <TextField
+                  label="Buscador por CUIL"
+                  value={filtroCuil}
+                  onChange={(e) => setFiltroCuil(e.target.value)}
+                  size="small"
+                  placeholder="Ingresá el CUIL a buscar..."
+                />
+              </div>
 
               <DataTableImport
-                data={filasTabla}
+                data={filasTablaFiltradas}
                 columns={columnasTabla}
                 size="small"
                 pageSizeOptions={[5, 10, 15]}


### PR DESCRIPTION
[ART RURAL] - [ART Gestión Integral - Formularios RAR - buscador de trabajador por CUIL] - [21/04/2026]

 

Actualizo:

Se incorporó un buscador de trabajadores por CUIL dentro de la grilla del formulario RAR, con el objetivo de facilitar la localización rápida de registros específicos, especialmente en formularios con gran volumen de trabajadores cargados.

La funcionalidad fue implementada tanto en la opción de alta como en la de edición del formulario, permitiendo filtrar dinámicamente los trabajadores visualizados en pantalla según el CUIL ingresado.

Con esta mejora:

el usuario puede buscar trabajadores por CUIL dentro del listado;

al aplicar el filtro, se muestran únicamente los registros coincidentes;

el filtro puede limpiarse para volver a visualizar la totalidad de trabajadores cargados;

la búsqueda afecta únicamente la visualización de la grilla, sin modificar ni alterar los datos cargados.

Además, se mantuvo el comportamiento actual del formulario, permitiendo continuar con la edición normal sobre los registros encontrados, tanto en formularios cargados manualmente como en formularios replicados o importados masivamente.

Así mismo se arreglo un bug que no traia los establecimientos.

Se formateo los datos de cuil para que tengamos con las mismas unificaciones que tenemos en todo el ambiente ##-##.###.###-#

<img width="1200" height="578" alt="image" src="https://github.com/user-attachments/assets/65eba1aa-017a-43d1-b74b-f095f9c950d7" />
