### PR TITLE
fix: ocultar Ver Detalles en cards sin link de indicador

### DIFF
--- a/src/app/inicio/page.tsx
+++ b/src/app/inicio/page.tsx
@@ -38,13 +38,18 @@ const InicioPage = () => {
           </Box>
         ) : indicadores && indicadores.length > 0 ? (
           indicadores.map((indicador: IndicadorDTO, index: number) => {
-            const baseLink = indicador.link ?? "";
+            const baseLink = (indicador.link ?? "").trim();
             const params = new URLSearchParams();
             if (indicador.filtroId != null) {
               params.set("filtroId", String(indicador.filtroId));
               params.set("filtroNombre", indicador.descripcion ?? "");
             }
-            const link = params.toString() ? `${baseLink}${baseLink.includes("?") ? "&" : "?"}${params}` : baseLink;
+            const link =
+              baseLink.length === 0
+                ? ""
+                : params.toString()
+                  ? `${baseLink}${baseLink.includes("?") ? "&" : "?"}${params}`
+                  : baseLink;
             return (
               <Card
                 key={indicador.id}

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -21,6 +21,8 @@ const Card: React.FC<CardProps> = ({
   link,
   borderColorClass = 'border-purple', // Valor por defecto si no se pasa
 }) => {
+  const trimmedLink = (link ?? "").trim();
+
   return (
     <div className={`${styles.card} ${styles[borderColorClass]}`}>
       <div className={styles.cardContent}>
@@ -37,8 +39,8 @@ const Card: React.FC<CardProps> = ({
           </div>
         )}
         {lastUpdated && <p className={styles.lastUpdated}>Última actualización : {lastUpdated}</p>}
-        {link && (
-          <Link href={link} className={styles.link}>
+        {trimmedLink && (
+          <Link href={trimmedLink} className={styles.link}>
             Ver Detalles →
           </Link>
         )}


### PR DESCRIPTION
No muestra el enlace si el link está vacío o solo tiene espacios, y evita armar query params sin ruta base en inicio.