### PR TITLE
Feature/ajustes 200526

### DIFF
--- a/src/app/inicio/comercializador/administracionComercializadores/page.tsx
+++ b/src/app/inicio/comercializador/administracionComercializadores/page.tsx
@@ -310,6 +310,9 @@ export default function AdminUserPage() {
   };
 
   const canCreateForTab = (tabIndex: number) => {
+    if (tabIndex === 0 && hasTask('Comercializador_Administracion_CrearGrupoOrganizador')) return true;
+    if (tabIndex === 1 && hasTask('Comercializador_Administracion_CrearOrganizadorComercializador')) return true;
+    if (tabIndex === 2 && hasTask('Comercializador_Administracion_CrearComercializador')) return true;
     if (isComercializador) return false;
     if (isOrganizadorComercializador) return tabIndex === 2; // solo Comercializador
     if (isGrupoOrganizador) return tabIndex === 1 || tabIndex === 2; // Organizador o Comercializador

--- a/src/app/inicio/usuarios/UsuarioForm.tsx
+++ b/src/app/inicio/usuarios/UsuarioForm.tsx
@@ -79,7 +79,7 @@ export interface UsuarioFormFields {
   sectorId?: number;
 }
 
-const ROLES_EXCLUIDOS_USUARIOS = ["comercializador", "grupoorganizador", "organizadorcomercializador"];
+const ROLES_EXCLUIDOS_USUARIOS = ["comercializador", "grupoorganizador", "organizadorcomercializador", "administrador"];
 
 export interface Props {
   open: boolean;

--- a/src/app/inicio/usuarios/page.tsx
+++ b/src/app/inicio/usuarios/page.tsx
@@ -85,6 +85,7 @@ function buildUsuarioUpdatePayload(data: UsuarioFormFields): UsuarioUpdatePayloa
     ...(data.password ? { password: String(data.password) } : {}),
     ...(data.confirmPassword ? { confirmPassword: String(data.confirmPassword) } : {}),
     email: String(data.email ?? "").trim(),
+    rol: String(data.rol ?? ""),
   };
 }
 

--- a/src/data/usuarioAPI.ts
+++ b/src/data/usuarioAPI.ts
@@ -142,6 +142,7 @@ export type UsuarioUpdatePayload = {
   password?: string;
   confirmPassword?: string;
   email: string;
+  rol: string;
 };
 //#region /api/Roles types
 //#endregion /api/Roles types


### PR DESCRIPTION
[ART RURAL] - [ArtGestion - Módulo Usuarios | Restringir creación de usuarios de Comercializador] - [18/05/2026]

Actualizo:

Se deja de mostrar el rol “Administrador“.

Se lo coloca en gris al momento de editar.

-----------------------------------------------------

[ART RURAL] - [ART Gestión integral - Usuarios - Sector] - [Fecha: 13/04/2026 ]

Cambios en backend: se pidio a Ciro cambios en el put de usuarios. Test ok de la api.

Actualizo:

Se adapto la edición del usuario a front para que se pueda cambiar de rol