### PR TITLE
Feat: Baja realcion empresa / usuario nueva logica

### DIFF
--- a/src/app/inicio/usuarios/UsuarioEmpresasUsuarioTab.tsx
+++ b/src/app/inicio/usuarios/UsuarioEmpresasUsuarioTab.tsx
@@ -1,11 +1,10 @@
 "use client";
 
 import { useMemo, useState, useCallback, useEffect } from "react";
-import useSWR from "swr";
 import { Box, Typography } from "@mui/material";
 import { ColumnDef } from "@tanstack/react-table";
 import axios, { AxiosError } from "axios";
-import AuthAPI, { token, type Empresa } from "@/data/authAPI";
+import AuthAPI, { type Empresa, type UsuarioEmpresasListadoEmpresaVm } from "@/data/authAPI";
 import { useAuth } from "@/data/AuthContext";
 import { useEmpresasStore } from "@/data/empresasStore";
 import CustomSelectSearch from "@/utils/ui/form/CustomSelectSearch";
@@ -14,7 +13,7 @@ import CustomButton from "@/utils/ui/button/CustomButton";
 import CustomModalMessage, { MessageType } from "@/utils/ui/message/CustomModalMessage";
 import Formato from "@/utils/Formato";
 
-export type UsuarioEmpresaPorCuitFila = Empresa & { id?: number };
+export type UsuarioEmpresaPorCuitFila = Empresa & { relacionId: number };
 type EmpresaComboOption = Pick<Empresa, "empresaId" | "cuit" | "razonSocial">;
 
 export type EmpresasRelacionadasMeta = {
@@ -27,8 +26,10 @@ type UsuarioEmpresasUsuarioTabProps = {
   usuarioId: string;
   cuitForm: string;
   puedeEditar: boolean;
+  empresasIniciales?: UsuarioEmpresasListadoEmpresaVm[];
   /** Notifica cantidad de empresas vinculadas y estado de carga (p. ej. bloqueo de cierre del modal tras alta). */
   onEmpresasRelacionadasMetaChange?: (meta: EmpresasRelacionadasMeta) => void;
+  onMutate?: () => Promise<void>;
 };
 
 export function UsuarioEmpresasUsuarioTab({
@@ -36,9 +37,11 @@ export function UsuarioEmpresasUsuarioTab({
   usuarioId,
   cuitForm,
   puedeEditar,
+  empresasIniciales,
   onEmpresasRelacionadasMetaChange,
+  onMutate,
 }: UsuarioEmpresasUsuarioTabProps) {
-  const { hasTask } = useAuth();
+  const { hasTask, user } = useAuth();
   const { empresas: empresasStore } = useEmpresasStore();
   const [empresaAAgregar, setEmpresaAAgregar] = useState<EmpresaComboOption | null>(null);
   const [isMutating, setIsMutating] = useState(false);
@@ -53,20 +56,43 @@ export function UsuarioEmpresasUsuarioTab({
     return Number.isFinite(n) && n > 0 ? n : null;
   }, [cuitForm]);
 
-  const swrKey =
-    open && usuarioId && cuitNum
-      ? ([AuthAPI.getEmpresasURL({ CUIT: cuitNum }), token.getToken(), usuarioId] as const)
-      : null;
-
-  const { data, error, isLoading, mutate } = useSWR(
-    swrKey,
-    () => AuthAPI.getEmpresas({ CUIT: cuitNum! })
+  const { data, error, isLoading, mutate } = AuthAPI.useGetEmpresas(
+    open && usuarioId && cuitNum ? { CUIT: cuitNum } : undefined
   );
 
-  const rows: UsuarioEmpresaPorCuitFila[] = useMemo(
-    () => (Array.isArray(data) ? (data as UsuarioEmpresaPorCuitFila[]) : []),
-    [data]
+  const { data: empresasLogueado } = AuthAPI.useGetEmpresas(
+    open && user?.cuit ? { CUIT: user.cuit } : undefined
   );
+
+  // Empresas activas del usuario (sin fecha de baja), con el id de relación cruzado
+  const relacionesActivas = useMemo(() => {
+    const activas = new Set(
+      (empresasIniciales ?? [])
+        .filter((e) => e.fechaBaja == null)
+        .map((e) => e.empresaId)
+    );
+    return activas;
+  }, [empresasIniciales]);
+
+  const relacionById = useMemo(() => {
+    const map = new Map<number, number>();
+    (empresasIniciales ?? [])
+      .filter((e) => e.fechaBaja == null)
+      .forEach((e) => map.set(e.empresaId, e.id));
+    return map;
+  }, [empresasIniciales]);
+
+  const empresasLogueadoIds = useMemo(
+    () => new Set((empresasLogueado ?? []).map((e) => e.empresaId)),
+    [empresasLogueado]
+  );
+
+  const rows = useMemo<UsuarioEmpresaPorCuitFila[]>(() => {
+    if (!Array.isArray(data)) return [];
+    return (data as Empresa[])
+      .filter((e) => relacionesActivas.has(e.empresaId) && empresasLogueadoIds.has(e.empresaId))
+      .map((e) => ({ ...e, relacionId: relacionById.get(e.empresaId) ?? 0 }));
+  }, [data, relacionesActivas, relacionById, empresasLogueadoIds]);
 
   useEffect(() => {
     if (!open || !onEmpresasRelacionadasMetaChange) return;
@@ -74,10 +100,7 @@ export function UsuarioEmpresasUsuarioTab({
       onEmpresasRelacionadasMetaChange({ count: 0, isLoading: false });
       return;
     }
-    onEmpresasRelacionadasMetaChange({
-      count: rows.length,
-      isLoading,
-    });
+    onEmpresasRelacionadasMetaChange({ count: rows.length, isLoading });
   }, [open, cuitNum, usuarioId, rows.length, isLoading, onEmpresasRelacionadasMetaChange]);
 
   const empresasSesionParaCombo = useMemo<EmpresaComboOption[]>(
@@ -107,18 +130,12 @@ export function UsuarioEmpresasUsuarioTab({
 
   const handleDarDeBaja = useCallback(
     async (row: UsuarioEmpresaPorCuitFila) => {
-      if (row.id == null) {
-        showModalMessage(
-          "No se puede dar de baja: el servicio no devolvió el identificador de la relación usuario–empresa (id).",
-          "error"
-        );
-        return;
-      }
       setIsMutating(true);
       try {
-        await AuthAPI.deleteUsuariosEmpresasBorrar(row.id);
-        showModalMessage("Empresa desvinculada correctamente.", "success");
+        await AuthAPI.deleteUsuariosEmpresasBorrar(row.relacionId);
+        void onMutate?.();
         await mutate();
+        showModalMessage("Empresa desvinculada correctamente.", "success");
       } catch (err) {
         const msg =
           axios.isAxiosError(err)
@@ -134,7 +151,7 @@ export function UsuarioEmpresasUsuarioTab({
         setIsMutating(false);
       }
     },
-    [mutate, showModalMessage]
+    [mutate, onMutate, showModalMessage]
   );
 
   const handleAgregarEmpresa = useCallback(async () => {
@@ -160,9 +177,10 @@ export function UsuarioEmpresasUsuarioTab({
         });
       }
 
+      void onMutate?.();
+      await mutate();
       showModalMessage("Empresa agregada correctamente.", "success");
       setEmpresaAAgregar(null);
-      await mutate();
     } catch (err) {
       const msg =
         axios.isAxiosError(err)
@@ -177,7 +195,7 @@ export function UsuarioEmpresasUsuarioTab({
     } finally {
       setIsMutating(false);
     }
-  }, [empresaAAgregar, mutate, showModalMessage, usuarioId]);
+  }, [empresaAAgregar, mutate, onMutate, showModalMessage, usuarioId]);
 
   const columns = useMemo<ColumnDef<UsuarioEmpresaPorCuitFila>[]>(
     () => [
@@ -198,7 +216,7 @@ export function UsuarioEmpresasUsuarioTab({
           <CustomButton
             type="button"
             color="secondary"
-            disabled={!puedeEditar || !canDarDeBajaEmpresa || row.original.id == null || isMutating}
+            disabled={!canDarDeBajaEmpresa || isMutating}
             onClick={() => void handleDarDeBaja(row.original)}
           >
             Dar de baja
@@ -206,7 +224,7 @@ export function UsuarioEmpresasUsuarioTab({
         ),
       },
     ],
-    [handleDarDeBaja, puedeEditar, canDarDeBajaEmpresa, isMutating]
+    [handleDarDeBaja, canDarDeBajaEmpresa, isMutating]
   );
 
   if (!cuitNum) {

--- a/src/app/inicio/usuarios/UsuarioForm.tsx
+++ b/src/app/inicio/usuarios/UsuarioForm.tsx
@@ -97,6 +97,7 @@ export interface Props {
   /** Tras registrar usuario: forzar pestaña Empresas y al menos una relación antes de cerrar el modal. */
   awaitingEmpresaRelation?: boolean;
   onEmpresaRelationSatisfied?: () => void;
+  onEmpresaMutate?: () => Promise<void>;
 }
 
 const initialFormState: UsuarioFormFields = {
@@ -205,6 +206,7 @@ export default function UsuarioForm({
   isAdmin = false,
   awaitingEmpresaRelation = false,
   onEmpresaRelationSatisfied,
+  onEmpresaMutate,
 }: Props) {
   const [form, setForm] = useState<UsuarioFormFields>(initialFormState);
   const [errors, setErrors] = useState<ValidationErrors>({});
@@ -1147,7 +1149,9 @@ export default function UsuarioForm({
                                 usuarioId={String(form.id ?? "")}
                                 cuitForm={form.cuit}
                                 puedeEditar={isEditing}
+                                empresasIniciales={usuarios.find((u) => String(u.id) === String(form.id))?.empresas}
                                 onEmpresasRelacionadasMetaChange={handleEmpresasRelacionadasMetaChange}
+                                onMutate={onEmpresaMutate}
                               />
                             </>
                           ),

--- a/src/app/inicio/usuarios/interfaces/UsuarioRow.tsx
+++ b/src/app/inicio/usuarios/interfaces/UsuarioRow.tsx
@@ -1,4 +1,5 @@
 import IModulo from "./IModulo";
+import { type UsuarioEmpresasListadoEmpresaVm } from "@/data/authAPI";
 
 export default interface UsuarioRow {
   id: number | string;
@@ -20,5 +21,6 @@ export default interface UsuarioRow {
   empresaId: number;
   deletedDate: string | null;
   modulos: IModulo[];
+  empresas?: UsuarioEmpresasListadoEmpresaVm[];
   // Add other fields if needed
 }

--- a/src/app/inicio/usuarios/page.tsx
+++ b/src/app/inicio/usuarios/page.tsx
@@ -238,7 +238,8 @@ export default function UsuariosPage() {
     usuarioDarDeBaja,
     usuarioReactivar,
     usuarioReestablecer,
-    usuarioReenviarCorreo
+    usuarioReenviarCorreo,
+    mutateUsuarios,
   } = useUsuarios({
     porEmpresaIds: porEmpresaIdsListado,
     allowEmptyEmpresasPost: allowEmptyEmpresasPostUsuarios,
@@ -697,6 +698,7 @@ const handleSubmit = async (data: UsuarioFormFields) => {
         isSubmitting={isSubmitting}
         awaitingEmpresaRelation={awaitingEmpresaAfterCreate}
         onEmpresaRelationSatisfied={handleEmpresaRelationSatisfied}
+        onEmpresaMutate={mutateUsuarios}
       />
 
       <Tareas

--- a/src/app/inicio/usuarios/useUsuarios.tsx
+++ b/src/app/inicio/usuarios/useUsuarios.tsx
@@ -53,6 +53,7 @@ function mapUsuarioEmpresasLogueadoItemToRow(
     empresaId: firstEmpresa?.empresaId ?? 0,
     deletedDate: u.deletedDate ?? null,
     modulos: (u.modulos ?? []) as UsuarioRow["modulos"],
+    empresas: u.empresas,
   };
 }
 
@@ -338,6 +339,7 @@ export default function useUsuarios(listFilter?: UseUsuariosListFilter) {
     usuarioDarDeBaja,
     usuarioReactivar,
     usuarioReestablecer,
-    usuarioReenviarCorreo
+    usuarioReenviarCorreo,
+    mutateUsuarios,
   };
 };

--- a/src/data/authAPI.ts
+++ b/src/data/authAPI.ts
@@ -237,7 +237,7 @@ export class AuthAPIClass extends ExternalAPI {
 
   deleteUsuariosEmpresasBorrar = async (id: number | string) =>
     tokenizable
-      .delete(this.deleteUsuariosEmpresasBorrarURL(id))
+      .patch(this.deleteUsuariosEmpresasBorrarURL(id), {})
       .then(async (response) => {
         if (response.status === 200 || response.status === 204) return;
         return Promise.reject(


### PR DESCRIPTION
**[ART RURAL] - [ART - Usuarios Empresas - Botón Dar de Baja no se habilita según permisos] - [02/06/2026]**

**Actualización**

Se verificó el funcionamiento de la acción **"Dar de Baja"** dentro de **Usuarios → Modificar Usuario → Empresas del Usuario**.

La baja de una asociación Usuario-Empresa se encuentra controlada por la tarea **"Usuarios_UsuariosEmpresas_DarDeBaja"**. Cuando el usuario posee dicha tarea asignada, el botón **"Dar de Baja"** se habilita correctamente y permite realizar la operación sobre la tabla **UsuariosEmpresas**.

Asimismo, se validó el comportamiento de visibilidad de las asociaciones según los permisos del usuario. Los usuarios que poseen empresas asociadas únicamente visualizan las relaciones correspondientes a sus propias empresas y solo pueden administrar dichas asociaciones.

Por ejemplo, el usuario **Médico Auditor (CUIT 27-32184234-3)** posee asociaciones con las empresas **Sanches y Sanches** y **Polimetal**. Sin embargo, al ingresar con un usuario asociado únicamente a **Sanches y Sanches**, solo se visualizan y administran las asociaciones correspondientes a esa empresa, sin acceso a las asociaciones de otras compañías.
