### PR TITLE
Feat: ajustes de permisos rol para dar de baja una asociacion empresausuario

### DIFF
--- a/src/app/inicio/empleador/formularioRAR/generar/FormularioRARGenerar.tsx
+++ b/src/app/inicio/empleador/formularioRAR/generar/FormularioRARGenerar.tsx
@@ -30,7 +30,7 @@ const cuipFormatter = (v: any) => Formato.CUIP(v);
 const normalizarCuil = (v: string) => (v || '').replace(/\D/g, '');
 
 interface CrearProps {
-  cuit: number;
+  cuit?: number;
   internoEstablecimiento?: number; // opcional en creación
   referenteDatos?: unknown;
   finalizaCarga: (ret?: boolean) => void;
@@ -132,6 +132,8 @@ const FormularioRARCrear: React.FC<CrearProps> = ({
   const [filtroCuil, setFiltroCuil] = React.useState<string>('');
 
   const guardandoRef = React.useRef(false);
+
+  const establecimientoReplicaRef = React.useRef<string | null>(null);
 
   // ===== Funciones para manejo de trabajadores =====
   // Función para editar un trabajador
@@ -539,12 +541,23 @@ React.useEffect(() => {
       const data = await ArtAPI.getFormularioRARById(replicaDe);
       if (cancel) return;
 
+      // En réplica, siempre usar el CUIT y razón social del formulario original
+      const cuitOriginal = data.cuit || (data as any).CUIT;
+      if (cuitOriginal) {
+        setCuitActual(String(cuitOriginal));
+      }
+      const razonSocialOriginal = data.empresaRazonSocial || (data as any).EmpresaRazonSocial || (data as any).razonSocial;
+      if (razonSocialOriginal) {
+        setRazonSocialActual(String(razonSocialOriginal));
+      }
+
       // Cantidades
       setCantExpuestos(String(data.cantTrabajadoresExpuestos || 0));
       setCantNoExpuestos(String(data.cantTrabajadoresNoExpuestos || 0));
 
       // Establecimiento (interno)
       if (data.internoEstablecimiento) {
+        establecimientoReplicaRef.current = String(data.internoEstablecimiento);
         setEstablecimientoSeleccionado(String(data.internoEstablecimiento));
       }
 
@@ -615,9 +628,15 @@ React.useEffect(() => {
         if (!cancel) setOpcionesEstablecimientos(opciones);
 
         // Preselección si viene por props
-        if (!cancel && internoEstablecimiento && String(internoEstablecimiento) !== '0' && opciones.length > 0) {
-          const existe = opciones.some(o => o.interno === String(internoEstablecimiento));
-          if (existe) setEstablecimientoSeleccionado(String(internoEstablecimiento));
+        if (!cancel && opciones.length > 0) {
+          const internoReplica = establecimientoReplicaRef.current;
+          if (internoReplica && internoReplica !== '0') {
+            const existe = opciones.some(o => o.interno === internoReplica);
+            if (existe) setEstablecimientoSeleccionado(internoReplica);
+          } else if (internoEstablecimiento && String(internoEstablecimiento) !== '0') {
+            const existe = opciones.some(o => o.interno === String(internoEstablecimiento));
+            if (existe) setEstablecimientoSeleccionado(String(internoEstablecimiento));
+          }
         }
 
         // Agentes

--- a/src/app/inicio/empleador/formularioRAR/generar/FormularioRARGenerar.tsx
+++ b/src/app/inicio/empleador/formularioRAR/generar/FormularioRARGenerar.tsx
@@ -542,14 +542,8 @@ React.useEffect(() => {
       if (cancel) return;
 
       // En réplica, siempre usar el CUIT y razón social del formulario original
-      const cuitOriginal = data.cuit || (data as any).CUIT;
-      if (cuitOriginal) {
-        setCuitActual(String(cuitOriginal));
-      }
-      const razonSocialOriginal = data.empresaRazonSocial || (data as any).EmpresaRazonSocial || (data as any).razonSocial;
-      if (razonSocialOriginal) {
-        setRazonSocialActual(String(razonSocialOriginal));
-      }
+      if (data.cuit) setCuitActual(String(data.cuit));
+      if (data.empresaRazonSocial) setRazonSocialActual(data.empresaRazonSocial);
 
       // Cantidades
       setCantExpuestos(String(data.cantTrabajadoresExpuestos || 0));

--- a/src/app/inicio/empleador/formularioRAR/page.tsx
+++ b/src/app/inicio/empleador/formularioRAR/page.tsx
@@ -1088,12 +1088,12 @@ const FormulariosRAR: React.FC = () => {
         </div>
       ) : viewMode === 'crear' ? (
         <FormularioRARGenerar
-          cuit={empresaSeleccionada?.cuit ?? cuit}
+          cuit={replicaDe ? undefined : (empresaSeleccionada?.cuit ?? cuit)}
           internoEstablecimiento={internoEstablecimiento}
           finalizaCarga={handleFinalizaCarga}
           formulariosRAR={formulariosRAR}
           replicaDe={replicaDe}
-          razonSocial={empresaSeleccionada?.razonSocial}
+          razonSocial={replicaDe ? undefined : empresaSeleccionada?.razonSocial}
         />
       ) : (
         <FormularioRARGenerar

--- a/src/app/inicio/empleador/formularioRGRL/FormulariosRGRL.tsx
+++ b/src/app/inicio/empleador/formularioRGRL/FormulariosRGRL.tsx
@@ -1120,7 +1120,7 @@ const FormulariosRGRL: React.FC<FormulariosRGRLProps> = ({ cuit, referenteDatos 
       >
         <GenerarFormularioRGRL
           //Generar
-          initialCuit={empresaSeleccionada?.cuit || undefined}
+          initialCuit={replicaDe ? undefined : (empresaSeleccionada?.cuit || undefined)}
           empresasIdGetBySpecs={empresasIdGetBySpecsModalGenerar}
           replicaDe={replicaDe}
           onClose={() => setOpenGenerar(false)}

--- a/src/app/inicio/empleador/formularioRGRL/generar/GenerarFormularioRGRL.tsx
+++ b/src/app/inicio/empleador/formularioRGRL/generar/GenerarFormularioRGRL.tsx
@@ -280,8 +280,10 @@ const GenerarFormularioRGRL: React.FC<{
       const c = Number((frm as any).cuit ?? 0) || undefined;
       if (c) setCuit(c);
 
+      const empresaIdReplica = c != null ? empresaIdDesdeStorePorCuit(empresas, c) : undefined;
+      const empresasIdReplica = empresaIdReplica != null ? [empresaIdReplica] : (empresaIdFromEditUrl != null ? [empresaIdFromEditUrl] : []);
       const [formulariosRes, ests, tfs] = await Promise.all([
-        c ? ArtAPI.getFormulariosRGRL(buildGetBySpecsParams({ CUIT: c, PageIndex: 1, PageSize: 1 })) : Promise.resolve({ data: [], index: 0, size: 0, pages: 0, count: 0 }),
+        c ? ArtAPI.getFormulariosRGRL({ CUIT: c, empresasId: empresasIdReplica, PageIndex: 1, PageSize: 1 }) : Promise.resolve({ data: [], index: 0, size: 0, pages: 0, count: 0 }),
         c ? fetchEstablecimientos(c) : Promise.resolve([] as Establecimiento[]),
         ArtAPI.getTiposFormulariosRGRL(),
       ]);

--- a/src/app/inicio/usuarios/UsuarioEmpresasUsuarioTab.tsx
+++ b/src/app/inicio/usuarios/UsuarioEmpresasUsuarioTab.tsx
@@ -60,8 +60,10 @@ export function UsuarioEmpresasUsuarioTab({
     open && usuarioId && cuitNum ? { CUIT: cuitNum } : undefined
   );
 
+  const esSinEmpresaAsociada = user?.rol === "Administrador" || user?.rol === "AdministradorArt";
+
   const { data: empresasLogueado } = AuthAPI.useGetEmpresas(
-    open && user?.cuit ? { CUIT: user.cuit } : undefined
+    open && !esSinEmpresaAsociada && user?.cuit ? { CUIT: user.cuit } : undefined
   );
 
   // Empresas activas del usuario (sin fecha de baja), con el id de relación cruzado
@@ -90,9 +92,9 @@ export function UsuarioEmpresasUsuarioTab({
   const rows = useMemo<UsuarioEmpresaPorCuitFila[]>(() => {
     if (!Array.isArray(data)) return [];
     return (data as Empresa[])
-      .filter((e) => relacionesActivas.has(e.empresaId) && empresasLogueadoIds.has(e.empresaId))
+      .filter((e) => relacionesActivas.has(e.empresaId) && (esSinEmpresaAsociada || empresasLogueadoIds.has(e.empresaId)))
       .map((e) => ({ ...e, relacionId: relacionById.get(e.empresaId) ?? 0 }));
-  }, [data, relacionesActivas, relacionById, empresasLogueadoIds]);
+  }, [data, relacionesActivas, relacionById, empresasLogueadoIds, esSinEmpresaAsociada]);
 
   useEffect(() => {
     if (!open || !onEmpresasRelacionadasMetaChange) return;


### PR DESCRIPTION
[ART RURAL] - [ART - Usuarios Empresas - Botón Dar de Baja no se habilita según permisos] - [02/06/2026]

 

Actualizo:

Se realizaron los ajustes pedidos en donde:

Si el usuario logueado NO es rol Administrador o AdministradorArt entonces la lógica se mantiene. Ejemplo: Sanchez&Sanchez:

<img width="1920" height="925" alt="image" src="https://github.com/user-attachments/assets/429ee1c1-d5d3-4322-8529-8753ae13b020" />


Si el usuario posee ROL Administrador o AdministradorArt entonces se mostrará para dar de baja cualquier asociación entre empresa y usuario:

<img width="3933" height="928" alt="image" src="https://github.com/user-attachments/assets/d5b4b1e6-f10e-4afc-972b-4f59e3b28e94" />