### PR TITLE
Feat: se cambia matricula de rol seguridad e higiene a alfanumerico

### DIFF
--- a/src/app/inicio/usuarios/UsuarioForm.tsx
+++ b/src/app/inicio/usuarios/UsuarioForm.tsx
@@ -191,6 +191,9 @@ export interface TouchedFields {
 export const LEYENDA_ASOCIAR_EMPRESA_ANTES_DE_GUARDAR =
   "Debe asociar al menos una empresa desde la solapa 'Empresas del usuario' antes de guardar los cambios.";
 
+// Título a mostrar cuando el usuario ya fue registrado pero necesita relacionar empresas
+export const TITULO_USUARIO_REGISTRADO = "Usuario Registrado";
+
 export default function UsuarioForm({
   open,
   onClose,
@@ -569,10 +572,10 @@ export default function UsuarioForm({
         }
       }
     } else if (name === "matricula") {
-      const numericValue = value.replace(/\D/g, '');
+      const matriculaValue = form.rol === "SeguridadEHigiene" ? value : value.replace(/\D/g, '');
       setForm((prev: UsuarioFormFields) => ({
         ...prev,
-        [name]: numericValue,
+        [name]: matriculaValue,
       }));
     } else {
       setForm((prev: UsuarioFormFields) => ({
@@ -1035,7 +1038,7 @@ export default function UsuarioForm({
                   fullWidth
                   required={!isDisabled && requiresTituloMatricula}
                   disabled={isDisabled}
-                  inputProps={{ inputMode: 'numeric', pattern: '[0-9]*' }}
+                  inputProps={form.rol === "SeguridadEHigiene" ? undefined : { inputMode: 'numeric', pattern: '[0-9]*' }}
                 />
               </div>
 

--- a/src/app/inicio/usuarios/page.tsx
+++ b/src/app/inicio/usuarios/page.tsx
@@ -544,16 +544,16 @@ const handleSubmit = async (data: UsuarioFormFields) => {
       };
 
       const baseSuccessTitle = successTitles[method as keyof typeof successTitles] || "Operación completada exitosamente";
-      const successTitle = successSecondaryMessage
-        ? `${baseSuccessTitle}. ${successSecondaryMessage}`
+      const defaultSuccessMessage =
+        successBodyMessages[method as keyof typeof successBodyMessages] ||
+        "Operación completada";
+      const modalTitleToShow = successSecondaryMessage
+        ? defaultSuccessMessage
         : baseSuccessTitle;
-      const successMessage = successBodyMessages[method as keyof typeof successBodyMessages] || "Operación completada";
-      showModalMessage(
-        successMessage,
-        "success",
-        undefined,
-        successTitle
-      );
+      const modalMessageToShow = successSecondaryMessage
+        ? successSecondaryMessage
+        : defaultSuccessMessage;
+      showModalMessage(modalMessageToShow, "success", undefined, modalTitleToShow);
       if (method !== "create" || !successSecondaryMessage) {
         handleCloseModal();
       }


### PR DESCRIPTION
[ART GESTION] - [TEMA: Matrícula Usr Higiene y Seguridad] - [Fecha: 02/06/2026]

Actualizo:

Desarrollo realizado
Se adecuó la validación del campo Matrícula en los módulos Crear Usuario y Modificar Usuario para contemplar el comportamiento requerido según el rol seleccionado.

Tareas realizadas
Se identificó la validación que restringía el campo Matrícula a valores exclusivamente numéricos.

Se modificó la lógica de validación para permitir el ingreso de valores alfanuméricos cuando el usuario posee el rol Seguridad e Higiene.

Se mantuvo la validación actual para el resto de los roles, preservando la restricción de ingreso numérico donde corresponde.

Se verificó el correcto almacenamiento de la información en la tabla ARTAuth.dbo.Usuarios.

Se realizaron pruebas de alta y modificación de usuarios para validar el nuevo comportamiento y asegurar que no existan impactos sobre la funcionalidad existente.

Resultado
Los usuarios con rol Seguridad e Higiene pueden registrar y modificar matrículas alfanuméricas correctamente, mientras que los demás roles continúan manteniendo el comportamiento previo de validación numérica.