### PR TITLE
Feature/ajustes comercializador poliza 010726

### DIFF
--- a/src/app/inicio/comercializador/polizas/historialPoliza/ModalVerPoliza.tsx
+++ b/src/app/inicio/comercializador/polizas/historialPoliza/ModalVerPoliza.tsx
@@ -26,7 +26,7 @@ export default function ModalVerPoliza({ historialId, onClose }: Props) {
   );
 
   const titulo = poliza
-    ? `Historial Poliza Número: ${(poliza as any).numero} - Fecha: ${Formato.Fecha((poliza as any).vigenciaHasta)}`
+    ? `Histo: ${(poliza as any).numero} - Fecha: ${Formato.Fecha((poliza as any).vigenciaHasta)}`
     : "Historial Poliza";
 
   return (

--- a/src/app/inicio/comercializador/polizas/historialPoliza/ModalVerPoliza.tsx
+++ b/src/app/inicio/comercializador/polizas/historialPoliza/ModalVerPoliza.tsx
@@ -2,6 +2,7 @@
 
 import { TextField } from "@mui/material";
 import CustomModal from "@/utils/ui/form/CustomModal";
+import CustomButton from "@/utils/ui/button/CustomButton";
 import SrtAPI from "@/data/srtAPI";
 import Formato from "@/utils/Formato";
 import styles from "./modalVerPoliza.module.css";
@@ -19,26 +20,35 @@ export default function ModalVerPoliza({ historialId, onClose }: Props) {
       label={label}
       value={value ?? ""}
       disabled
-      size="small"
       className={className}
       slotProps={{ inputLabel: { shrink: true } }}
     />
   );
 
+  const titulo = poliza
+    ? `Historial Poliza Número: ${(poliza as any).numero} - Fecha: ${Formato.Fecha((poliza as any).vigenciaHasta)}`
+    : "Historial Poliza";
+
   return (
-    <CustomModal open={!!historialId} onClose={onClose} title="Ver Póliza Completa" size="large">
+    <CustomModal
+      open={!!historialId}
+      onClose={onClose}
+      title={titulo}
+      size="large"
+      actions={<CustomButton color="secondary" onClick={onClose}>Cerrar</CustomButton>}
+    >
       {isLoading || !poliza ? null : (
         <div className={styles.grid}>
           <span className={styles.section}>Póliza</span>
-          {field("Número", (poliza as any).numero)}
-          {field("CUIT", Formato.CUIP(String((poliza as any).cuit ?? "")))}
-          {field("Nro. Solicitud", (poliza as any).numeroSolicitud)}
-          {field("Vigencia Desde", Formato.Fecha((poliza as any).vigenciaDesde))}
-          {field("Vigencia Hasta", Formato.Fecha((poliza as any).vigenciaHasta))}
-          {field("Estado", (poliza as any).estadoCodigo)}
-          {field("Fecha Estado", Formato.Fecha((poliza as any).estadoFecha))}
-          {field("Días para Vencimiento", (poliza as any).diasParaVencimiento)}
-          {field("CIIU", (poliza as any).ciiu)}
+          {field("Número", (poliza as any).numero, styles.w100)}
+          {field("CUIT", Formato.CUIP(String((poliza as any).cuit ?? "")), styles.w150)}
+          {field("Nro. Solicitud", (poliza as any).numeroSolicitud, styles.w120)}
+          {field("Vigencia Desde", Formato.Fecha((poliza as any).vigenciaDesde), styles.w120)}
+          {field("Vigencia Hasta", Formato.Fecha((poliza as any).vigenciaHasta), styles.w120)}
+          {field("Estado", (poliza as any).estadoCodigo, styles.w100)}
+          {field("Fecha Estado", Formato.Fecha((poliza as any).estadoFecha), styles.w120)}
+          {field("Días para Vencimiento", (poliza as any).diasParaVencimiento, styles.w160)}
+          {field("CIIU", (poliza as any).ciiu, styles.w100)}
 
           <span className={styles.section}>Empleador</span>
           {field("Denominación", (poliza as any).empleadorDenominacion, styles.col2)}

--- a/src/app/inicio/comercializador/polizas/historialPoliza/formularioComercializador.tsx
+++ b/src/app/inicio/comercializador/polizas/historialPoliza/formularioComercializador.tsx
@@ -24,6 +24,7 @@ type Props = {
   numeroPoliza?: string;
   editRow?: HistorialRow;
   crearHistorial?: boolean;
+  comercializadorActualInterno?: number;
 };
 
 const asociadosColumns: ColumnDef<SRTComercializadorAsociado>[] = [
@@ -32,7 +33,7 @@ const asociadosColumns: ColumnDef<SRTComercializadorAsociado>[] = [
   { accessorKey: "razonSocial", header: "Comercializador", meta: { align: "left" } },
 ];
 
-export default function FormularioComercializador({ open, onClose, onSuccess, empleadorCuit, empleadorRazonSocial, polizaInterno, numeroPoliza, editRow, crearHistorial }: Props) {
+export default function FormularioComercializador({ open, onClose, onSuccess, empleadorCuit, empleadorRazonSocial, polizaInterno, numeroPoliza, editRow, crearHistorial, comercializadorActualInterno }: Props) {
   const [comercializadorSeleccionado, setComercializadorSeleccionado] = useState<Comercializador | null>(null);
   const [asociadoSeleccionado, setAsociadoSeleccionado] = useState<SRTComercializadorAsociado | null>(null);
   const [seleccionarAsociados, setSeleccionarAsociados] = useState(false);
@@ -60,8 +61,10 @@ export default function FormularioComercializador({ open, onClose, onSuccess, em
       const com = comercializadores.find((c) => c.interno === editRow.srtComercializadorInterno) ?? null;
       setComercializadorSeleccionado(com);
       setFechaHasta(editRow.fechaHasta ? editRow.fechaHasta.slice(0, 10) : "");
+    } else if (comercializadorActualInterno != null && comercializadores.length > 0) {
+      setComercializadorSeleccionado(comercializadores.find((c) => c.interno === comercializadorActualInterno) ?? null);
     }
-  }, [open, editRow, comercializadores.length]);
+  }, [open, editRow, comercializadorActualInterno, comercializadores.length]);
 
   const cuitFormateado = Formato.CUIP(empleadorCuit.replace(/\D/g, "")) || empleadorCuit;
   const titulo = editRow

--- a/src/app/inicio/comercializador/polizas/historialPoliza/formularioComercializador.tsx
+++ b/src/app/inicio/comercializador/polizas/historialPoliza/formularioComercializador.tsx
@@ -23,6 +23,7 @@ type Props = {
   polizaInterno: number | undefined;
   numeroPoliza?: string;
   editRow?: HistorialRow;
+  crearHistorial?: boolean;
 };
 
 const asociadosColumns: ColumnDef<SRTComercializadorAsociado>[] = [
@@ -31,7 +32,7 @@ const asociadosColumns: ColumnDef<SRTComercializadorAsociado>[] = [
   { accessorKey: "razonSocial", header: "Comercializador", meta: { align: "left" } },
 ];
 
-export default function FormularioComercializador({ open, onClose, onSuccess, empleadorCuit, empleadorRazonSocial, polizaInterno, numeroPoliza, editRow }: Props) {
+export default function FormularioComercializador({ open, onClose, onSuccess, empleadorCuit, empleadorRazonSocial, polizaInterno, numeroPoliza, editRow, crearHistorial }: Props) {
   const [comercializadorSeleccionado, setComercializadorSeleccionado] = useState<Comercializador | null>(null);
   const [asociadoSeleccionado, setAsociadoSeleccionado] = useState<SRTComercializadorAsociado | null>(null);
   const [seleccionarAsociados, setSeleccionarAsociados] = useState(false);
@@ -65,13 +66,24 @@ export default function FormularioComercializador({ open, onClose, onSuccess, em
   const cuitFormateado = Formato.CUIP(empleadorCuit.replace(/\D/g, "")) || empleadorCuit;
   const titulo = editRow
     ? `Editar el historial del comercializador${numeroPoliza ? ` - Póliza: ${numeroPoliza}` : ""}`
+    : crearHistorial
+    ? `Nuevo registro de historial${numeroPoliza ? ` - Póliza: ${numeroPoliza}` : ""}`
     : `Modificar Comercializador${numeroPoliza ? ` - Póliza: ${numeroPoliza}` : ""}`;
 
   const handleGuardar = async () => {
     if (!comercializadorSeleccionado) return;
     setSaving(true);
     try {
-      if (editRow) {
+      if (crearHistorial) {
+        if (polizaInterno == null) return;
+        const body: SRTComercializadoresHistorialPutRequest = {
+          srtPolizaInterno: polizaInterno,
+          srtComercializadorInterno: comercializadorSeleccionado.interno,
+          srtComercializadorAsociadoInterno: seleccionarAsociados && asociadoSeleccionado ? asociadoSeleccionado.interno : null,
+          fechaHasta: fechaHasta ? new Date(fechaHasta).toISOString() : new Date().toISOString(),
+        };
+        await SrtAPI.postSRTComercializadoresHistorial(body);
+      } else if (editRow) {
         const body: SRTComercializadoresHistorialPutRequest = {
           srtPolizaInterno: editRow.srtPolizaInterno || (polizaInterno ?? 0),
           srtComercializadorInterno: comercializadorSeleccionado.interno,
@@ -102,7 +114,7 @@ export default function FormularioComercializador({ open, onClose, onSuccess, em
       open={resultado === "success"}
       type="success"
       title="Operación exitosa"
-      message={`Se modificó el comercializador a la póliza${numeroPoliza ? ` ${numeroPoliza}` : ""}`}
+      message={crearHistorial ? `Se creó el registro de historial${numeroPoliza ? ` para la póliza ${numeroPoliza}` : ""}` : `Se modificó el comercializador a la póliza${numeroPoliza ? ` ${numeroPoliza}` : ""}`}
       onClose={() => { setResultado(null); onClose(); }}
     />
     <CustomModalMessage
@@ -140,7 +152,7 @@ export default function FormularioComercializador({ open, onClose, onSuccess, em
           renderInput={(params) => <TextField {...params} label="Comercializador" />}
           className={styles.autocompleteField}
         />
-        {editRow && (
+        {(editRow || crearHistorial) && (
           <TextField
             label="Fecha Finalización"
             type="date"

--- a/src/app/inicio/comercializador/polizas/historialPoliza/historialPoliza.tsx
+++ b/src/app/inicio/comercializador/polizas/historialPoliza/historialPoliza.tsx
@@ -30,6 +30,7 @@ type Props = {
 export default function HistorialPoliza({ data, isLoading, hasSelection, empleadorCuit, empleadorRazonSocial, polizaInterno, onSuccess }: Props) {
   const { hasTask } = useAuth();
   const [modalOpen, setModalOpen] = useState(false);
+  const [crearOpen, setCrearOpen] = useState(false);
   const [editRow, setEditRow] = useState<HistorialRow | null>(null);
   const [bajaRow, setBajaRow] = useState<HistorialRow | null>(null);
   const [verPolizaId, setVerPolizaId] = useState<number | null>(null);
@@ -87,6 +88,11 @@ export default function HistorialPoliza({ data, isLoading, hasSelection, emplead
   return (
     <>
       {!hasSelection && <p className={styles.emptyMessage}>Seleccione una póliza para ver el historial.</p>}
+      {hasSelection && hasTask("Comercializador_Polizas_CrearHistorial") && (
+        <div className={styles.toolbar}>
+          <CustomButton onClick={() => setCrearOpen(true)}>Registrar historial de comercializador</CustomButton>
+        </div>
+      )}
       <DataTable
         columns={columns}
         data={data}
@@ -100,6 +106,15 @@ export default function HistorialPoliza({ data, isLoading, hasSelection, emplead
         empleadorRazonSocial={empleadorRazonSocial}
         polizaInterno={polizaInterno}
         numeroPoliza={data[0]?.numeroPoliza}
+      />
+      <FormularioComercializador
+        open={crearOpen}
+        onClose={() => { setCrearOpen(false); onSuccess(); }}
+        empleadorCuit={empleadorCuit}
+        empleadorRazonSocial={empleadorRazonSocial}
+        polizaInterno={polizaInterno}
+        numeroPoliza={data[0]?.numeroPoliza}
+        crearHistorial
       />
       <FormularioComercializador
         open={!!editRow}

--- a/src/app/inicio/comercializador/polizas/historialPoliza/modalVerPoliza.module.css
+++ b/src/app/inicio/comercializador/polizas/historialPoliza/modalVerPoliza.module.css
@@ -1,32 +1,37 @@
 .grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  display: flex;
+  flex-wrap: wrap;
   gap: 1rem 1.5rem;
 }
 
+.grid > * {
+  flex: 1 1 150px;
+}
+
 /* ── Span helpers ── */
-.full { grid-column: 1 / -1; }
-.half { grid-column: span 2; }
-.col1 { grid-column: span 1; }
-.col2 { grid-column: span 2; }
-.col3 { grid-column: span 3; }
+.full { flex-basis: 100%; }
+.half { flex: 1 1 calc(2 * 150px + 1.5rem); }
+.col1 { flex: 1 1 150px; }
+.col2 { flex: 1 1 calc(2 * 150px + 1.5rem); }
+.col3 { flex: 1 1 calc(3 * 150px + 3rem); }
 
 /* ── Width overrides (aplica dentro de la celda) ── */
-.w100 { width: 100px; }
-.w120 { width: 120px; }
-.w150 { width: 150px; }
-.w200 { width: 200px; }
-.w240 { width: 240px; }
-.w300 { width: 300px; }
+.w100 { flex: 0 0 100px; width: 100px; }
+.w120 { flex: 0 0 120px; width: 120px; }
+.w150 { flex: 0 0 150px; width: 150px; }
+.w160 { flex: 0 0 200px; width: 160px; }
+.w240 { flex: 0 0 240px; width: 240px; }
+.w300 { flex: 0 0 300px; width: 300px; }
 .w100pct { width: 100%; }
 
 /* ── Sections ── */
 .section {
-  grid-column: 1 / -1;
+  flex-basis: 100%;
+  font-size: 18px;
   font-weight: 600;
-  font-size: 0.85rem;
-  color: var(--grisOscuro, #555);
-  border-bottom: 1px solid #ddd;
-  padding-bottom: 4px;
+  color: #333;
+  border-bottom: 2px solid #e9ecef;
+  padding-bottom: 8px;
   margin-top: 0.5rem;
+  margin-bottom: 20px;
 }

--- a/src/app/inicio/comercializador/polizas/page.tsx
+++ b/src/app/inicio/comercializador/polizas/page.tsx
@@ -36,7 +36,7 @@ function digits(value: unknown) {
   return String(value ?? '').replace(/\D/g, '');
 }
 
-type PolizaRow = { interno: string; numero: string; NroPoliza: string; CUIT: string; Empleador_Denominacion: string; Comercializador_Denominacion: string; Vigencia_Desde: string; Vigencia_Hasta: string; fecha: string; };
+type PolizaRow = { interno: string; numero: string; NroPoliza: string; CUIT: string; Empleador_Denominacion: string; Comercializador_Denominacion: string; srtComercializadorInterno: number; Vigencia_Desde: string; Vigencia_Hasta: string; fecha: string; };
 
 function PolizasListado({
   params = {},
@@ -185,6 +185,7 @@ const columns: ColumnDef<Poliza>[] = [
       CUIT: String(item.cuit ?? ''),
       Empleador_Denominacion: String(item.empleadorDenominacion ?? ''),
       Comercializador_Denominacion: String(item.srtComercializadorDenominacion ?? item.comercializadorReferenteRazonSocial ?? ''),
+      srtComercializadorInterno: Number(item.srtcomercializadorInterno ?? item.srtComercializadorInterno ?? 0),
       Vigencia_Desde: String(item.vigenciaDesde ?? ''),
       Vigencia_Hasta: String(item.vigenciaHasta ?? ''),
       fecha: String(item.movimientoFecha ?? ''),
@@ -600,6 +601,7 @@ function PolizasPage() {
         empleadorRazonSocial={modalPoliza?.Empleador_Denominacion ?? ""}
         polizaInterno={modalPoliza ? Number(modalPoliza.interno) : undefined}
         numeroPoliza={modalPoliza?.numero}
+        comercializadorActualInterno={modalPoliza?.srtComercializadorInterno || undefined}
       />
     </>
   );

--- a/src/app/inicio/comercializador/polizas/page.tsx
+++ b/src/app/inicio/comercializador/polizas/page.tsx
@@ -316,7 +316,7 @@ const columns: ColumnDef<Poliza>[] = [
 }
 
 function PolizasPage() {
-  const { user } = useAuth();
+  const { user, hasTask } = useAuth();
   const rol = String((user as any)?.rol ?? '').toLowerCase();
   const cuil = Number(digits((user as any)?.cuit ?? (user as any)?.CUIL ?? (user as any)?.cuil ?? 0));
 
@@ -590,11 +590,7 @@ function PolizasPage() {
             />
           ),
         },
-        {
-          label: "Historial",
-          value: 1,
-          content: historial,
-        },
+        ...(hasTask("Comercializador_Polizas_Historial") ? [{ label: "Historial", value: 1, content: historial }] : []),
       ]}
     />
       <FormularioComercializador

--- a/src/app/inicio/comercializador/polizas/types/poliza.tsx
+++ b/src/app/inicio/comercializador/polizas/types/poliza.tsx
@@ -71,6 +71,7 @@ export type Poliza = {
     CUIT: string;
     Empleador_Denominacion: string;
     Comercializador_Denominacion: string;
+    srtComercializadorInterno: number;
     Vigencia_Desde: string;
     Vigencia_Hasta: string;
     fecha: string;

--- a/src/data/srtAPI.ts
+++ b/src/data/srtAPI.ts
@@ -807,7 +807,7 @@ export class SrtAPIClass extends ExternalAPI {
 
   //#region SRTComercializadoresHistorial por PolizaId
   readonly getSRTComercializadoresHistorialByPolizaIdURL = (polizaId: number) =>
-    this.getURL({ path: `/api/SRTPolizasHistorial/SRTPoliza/${polizaId}` }).toString();
+    this.getURL({ path: `/api/SRTPolizasHistorial/SRTPoliza/${polizaId}`, search: toURLSearch({ orderBy: "-fechaHasta" }) }).toString();
 
   getSRTComercializadoresHistorialByPolizaId = async (polizaId: number) =>
     tokenizable


### PR DESCRIPTION
**Revisión 1 - 01/07**

Se creó la nueva tarea **Comercializador_Polizas_Historial**, permitiendo administrar mediante permisos el acceso a la solapa Historial del módulo Pólizas.

**Revisión 2 - 01/07**

Se rediseñó la ventana de consulta del historial de cambios de comercializador, adecuando la distribución, tamaños y presentación de los controles al diseño estándar utilizado por las restantes pantallas de consulta del sistema.

**Revisión 3 - 01/07**

Se corrigió el registro del historial para que también genere una nueva entrada cuando se modifica la modalidad de administración de una póliza (Independiente ? Asociada a Organizador/Grupo), aun cuando el Comercializador permanezca siendo el mismo. De esta forma, cualquier cambio que impacte en la liquidación de premios/comisiones queda almacenado correctamente en **SRTPolizasHistorial**.

**Revisión 4 - 01/07**

Se incorporó la funcionalidad **Registrar cambio de comercializador**, agregando una nueva acción **Agregar**, controlada por su correspondiente permiso. La funcionalidad permite crear registros históricos de forma manual para completar antecedentes no registrados previamente. Al seleccionar la opción, se abre el mismo formulario utilizado para la edición del historial, con los datos de la póliza precargados, permitiendo informar el comercializador anterior, la fecha de vigencia hasta la cual administró la póliza y la modalidad de administración (Independiente o Asociada a Organizador/Grupo). Una vez validada la información, se genera el registro correspondiente en el historial, simulando un cambio realizado en la fecha indicada.