### PR TITLE
Feature/ajustes 010726

### DIFF
--- a/src/app/inicio/empleador/cobertura/HistorialTable.tsx
+++ b/src/app/inicio/empleador/cobertura/HistorialTable.tsx
@@ -4,12 +4,14 @@ import React, { useMemo, useState, useEffect } from 'react';
 import DataTable from '@/utils/ui/table/DataTable';
 import { ColumnDef } from '@tanstack/react-table';
 import styles from './cobertura.module.css';
+import CustomButton from '@/utils/ui/button/CustomButton';
 import CustomSelectSearch from '@/utils/ui/form/CustomSelectSearch';
 import { useEmpresasStore } from '@/data/empresasStore';
 import { Empresa } from '@/data/authAPI';
 import ArtAPI from '@/data/artAPI';
 import { HistItem } from './types/cobertura';
 import Formato from '@/utils/Formato';
+import { saveTable, type TableColumn } from '@/utils/excelUtils';
 
 export default function HistorialTable({ data, isLoading = false }: { data: HistItem[]; isLoading?: boolean }) {
   const { empresas, isLoading: isLoadingEmpresas } = useEmpresasStore();
@@ -24,6 +26,7 @@ export default function HistorialTable({ data, isLoading = false }: { data: Hist
     return String(empresa.razonSocial ?? '');
   };
   const columns: ColumnDef<HistItem>[] = useMemo(() => [
+    { header: 'Nro. Certificado', accessorKey: 'interno' },
     { header: 'CUIT Empleador', accessorKey: 'cuitEmpleador', cell: (info) => Formato.CUIP(info.getValue()) },
     { header: 'Póliza', accessorKey: 'poliza' },
     { header: 'Razón Social', accessorKey: 'razonSocial' },
@@ -36,13 +39,30 @@ export default function HistorialTable({ data, isLoading = false }: { data: Hist
   const [loading, setLoading] = useState<boolean>(false);
 
   useEffect(() => {
-    if (!empresaSeleccionada) return;
     setLoading(true);
-    void ArtAPI.getCobertura({ cuit: empresaSeleccionada.cuit }).then((resp) => {
+    void ArtAPI.getCobertura({ cuit: empresaSeleccionada?.cuit }).then((resp) => {
       setRows(resp as HistItem[]);
       setLoading(false);
     });
   }, [empresaSeleccionada]);
+
+  const handleExportExcel = async () => {
+    const columnsExcel: Record<string, TableColumn> = {
+      interno: { header: 'Nro. Certificado', key: 'interno' },
+      cuitEmpleador: { header: 'CUIT Empleador', key: 'cuitEmpleador' },
+      poliza: { header: 'Póliza', key: 'poliza' },
+      razonSocial: { header: 'Razón Social', key: 'razonSocial' },
+      destinatario: { header: 'Destinatario', key: 'destinatario' },
+      tipoCertificado: { header: 'Tipo Certificado', key: 'tipoCertificado' },
+      createdAt: { header: 'Fecha y Hora de Creación', key: 'createdAt' },
+    };
+    const rowsExcel = rows.map((row) => ({
+      ...row,
+      cuitEmpleador: Formato.CUIP(row.cuitEmpleador),
+      createdAt: Formato.FechaHora(row.createdAt),
+    }));
+    await saveTable(columnsExcel, rowsExcel, 'HistorialCertificadosCobertura.xlsx', { format: 'xlsx', sheet: { name: 'Historial' } });
+  };
 
   return (
     <div style={{ marginTop: 12 }}>
@@ -56,6 +76,11 @@ export default function HistorialTable({ data, isLoading = false }: { data: Hist
           placeholder="Buscar empresa..."
           loading={isLoadingEmpresas}
         />
+      </div>
+      <div className={styles.exportButtonContainer}>
+        <CustomButton onClick={handleExportExcel} disabled={loading || rows.length === 0}>
+          Exportar a Excel
+        </CustomButton>
       </div>
       <DataTable data={rows} columns={columns} size="mid" isLoading={isLoading || loading} />
     </div>

--- a/src/app/inicio/empleador/cobertura/HistorialTable.tsx
+++ b/src/app/inicio/empleador/cobertura/HistorialTable.tsx
@@ -36,17 +36,24 @@ export default function HistorialTable({ data, isLoading = false }: { data: Hist
   ], []);
 
   const [rows, setRows] = useState<HistItem[]>(data);
+  const [pageCount, setPageCount] = useState<number>(1);
+  const [page, setPage] = useState<number>(1);
   const [loading, setLoading] = useState<boolean>(false);
 
   useEffect(() => {
     setLoading(true);
-    void ArtAPI.getCobertura({ cuit: empresaSeleccionada?.cuit }).then((resp) => {
-      setRows(resp as HistItem[]);
+    void ArtAPI.getCobertura({ cuit: empresaSeleccionada?.cuit, pageIndex: page, pageSize: 10, orderBy: '-fechaHora' }).then((resp) => {
+      const { data, pages } = resp as { data: HistItem[]; pages: number };
+      setRows(data);
+      setPageCount(pages);
       setLoading(false);
     });
-  }, [empresaSeleccionada]);
+  }, [empresaSeleccionada, page]);
+
+  useEffect(() => { setPage(1); }, [empresaSeleccionada]);
 
   const handleExportExcel = async () => {
+    const { data: allRows } = (await ArtAPI.getCobertura({ cuit: empresaSeleccionada?.cuit, orderBy: '-fechaHora' })) as { data: HistItem[] };
     const columnsExcel: Record<string, TableColumn> = {
       interno: { header: 'Nro. Certificado', key: 'interno' },
       cuitEmpleador: { header: 'CUIT Empleador', key: 'cuitEmpleador' },
@@ -56,7 +63,7 @@ export default function HistorialTable({ data, isLoading = false }: { data: Hist
       tipoCertificado: { header: 'Tipo Certificado', key: 'tipoCertificado' },
       createdAt: { header: 'Fecha y Hora de Creación', key: 'createdAt' },
     };
-    const rowsExcel = rows.map((row) => ({
+    const rowsExcel = allRows.map((row) => ({
       ...row,
       cuitEmpleador: Formato.CUIP(row.cuitEmpleador),
       createdAt: Formato.FechaHora(row.createdAt),
@@ -82,7 +89,7 @@ export default function HistorialTable({ data, isLoading = false }: { data: Hist
           Exportar a Excel
         </CustomButton>
       </div>
-      <DataTable data={rows} columns={columns} size="mid" isLoading={isLoading || loading} />
+      <DataTable data={rows} columns={columns} size="mid" isLoading={isLoading || loading} manualPagination pageIndex={page} pageSize={10} pageCount={pageCount} onPageChange={setPage} />
     </div>
   );
 }

--- a/src/app/inicio/empleador/cobertura/HistorialTable.tsx
+++ b/src/app/inicio/empleador/cobertura/HistorialTable.tsx
@@ -13,9 +13,13 @@ import { HistItem } from './types/cobertura';
 import Formato from '@/utils/Formato';
 import { saveTable, type TableColumn } from '@/utils/excelUtils';
 
+const TODAS_LAS_EMPRESAS: Empresa = { empresaId: 0, cuit: 0, razonSocial: 'Todas las Empresas', domicilio: '', localidad: '', provincia: '' };
+
 export default function HistorialTable({ data, isLoading = false }: { data: HistItem[]; isLoading?: boolean }) {
   const { empresas, isLoading: isLoadingEmpresas } = useEmpresasStore();
-  const [empresaSeleccionada, setEmpresaSeleccionada] = useState<Empresa | null>(null);
+  const [empresaSeleccionada, setEmpresaSeleccionada] = useState<Empresa | null>(TODAS_LAS_EMPRESAS);
+
+  const opciones = useMemo(() => [TODAS_LAS_EMPRESAS, ...empresas], [empresas]);
 
   const handleEmpresaChange = (_event: React.SyntheticEvent, newValue: Empresa | null) => {
     setEmpresaSeleccionada(newValue);
@@ -41,8 +45,13 @@ export default function HistorialTable({ data, isLoading = false }: { data: Hist
   const [loading, setLoading] = useState<boolean>(false);
 
   useEffect(() => {
+    if (!empresaSeleccionada) {
+      setRows([]);
+      setPageCount(1);
+      return;
+    }
     setLoading(true);
-    void ArtAPI.getCobertura({ cuit: empresaSeleccionada?.cuit, pageIndex: page, pageSize: 10, orderBy: '-fechaHora' }).then((resp) => {
+    void ArtAPI.getCobertura({ cuit: empresaSeleccionada.cuit || undefined, pageIndex: page, pageSize: 10, orderBy: '-fechaHora' }).then((resp) => {
       const { data, pages } = resp as { data: HistItem[]; pages: number };
       setRows(data);
       setPageCount(pages);
@@ -53,7 +62,7 @@ export default function HistorialTable({ data, isLoading = false }: { data: Hist
   useEffect(() => { setPage(1); }, [empresaSeleccionada]);
 
   const handleExportExcel = async () => {
-    const { data: allRows } = (await ArtAPI.getCobertura({ cuit: empresaSeleccionada?.cuit, orderBy: '-fechaHora' })) as { data: HistItem[] };
+    const { data: allRows } = (await ArtAPI.getCobertura({ cuit: empresaSeleccionada?.cuit || undefined, orderBy: '-fechaHora' })) as { data: HistItem[] };
     const columnsExcel: Record<string, TableColumn> = {
       interno: { header: 'Nro. Certificado', key: 'interno' },
       cuitEmpleador: { header: 'CUIT Empleador', key: 'cuitEmpleador' },
@@ -75,7 +84,7 @@ export default function HistorialTable({ data, isLoading = false }: { data: Hist
     <div style={{ marginTop: 12 }}>
       <div className={styles.empresaSelectorContainer}>
         <CustomSelectSearch<Empresa>
-          options={empresas}
+          options={opciones}
           getOptionLabel={getEmpresaLabel}
           value={empresaSeleccionada}
           onChange={handleEmpresaChange}

--- a/src/app/inicio/empleador/cobertura/cobertura.module.css
+++ b/src/app/inicio/empleador/cobertura/cobertura.module.css
@@ -20,6 +20,12 @@
     margin-bottom: 20px;
 }
 
+.exportButtonContainer {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 12px;
+}
+
 @media (max-width: 768px) {
     .empresaSelectorContainer {
         max-width: 100%;

--- a/src/app/inicio/empleador/cobertura/types/cobertura.tsx
+++ b/src/app/inicio/empleador/cobertura/types/cobertura.tsx
@@ -10,6 +10,9 @@ export type CoberturaPostResponse = unknown;
 
 export type ParametersCobertura = {
     cuit?: number;
+    pageIndex?: number;
+    pageSize?: number;
+    orderBy?: string;
 }
 
 export type HistItem = {


### PR DESCRIPTION
- Se incorporó la columna **"Nro. Certificado"**, mostrando el Id/Interno del registro de historial generado para cada emisión de Certificado de Cobertura, tanto en la consulta como en la exportación.
- Se agregó el botón **"Exportar a Excel"** junto con la lógica necesaria para generar el archivo respetando las mismas columnas, el mismo orden y los filtros aplicados en la grilla.
- Se implementó la opción **"Todas las Empresas"**, permitiendo visualizar el historial completo de emisiones.
- Se incorporó la paginación del historial para optimizar la consulta cuando se visualizan grandes volúmenes de información y se ajustó el ordenamiento para mostrar los certificados por **fecha y hora descendente**, visualizando primero los registros más recientes.
- Se verificó el correcto funcionamiento de la consulta, la paginación, el ordenamiento y la exportación a Excel, dando por finalizada la implementación.