### PR TITLE
Fix: armado combo selector establecimientos rar y rgrl

### DIFF
--- a/src/app/inicio/empleador/formularioRAR/generar/FormularioRARGenerar.tsx
+++ b/src/app/inicio/empleador/formularioRAR/generar/FormularioRARGenerar.tsx
@@ -606,9 +606,9 @@ React.useEffect(() => {
         console.log(' Array procesado:', estArr);
 
         const opciones: OpcionEstablecimiento[] = estArr
-          .filter((est: any) => est && (est.nroSucursal || est.domicilioCalle || est.interno))
+          .filter((est: any) => est && (est.numero || est.domicilioCalle || est.interno))
           .map((est: any) => {
-            const nro = est.nroSucursal ?? est.interno ?? '';
+            const nro = est.numero ?? est.interno ?? '';
             const direccion = [est.domicilioCalle, est.domicilioNro].filter(Boolean).join(' ');
             return {
               interno: String(est.interno ?? ''),

--- a/src/app/inicio/empleador/formularioRGRL/generar/CabeceraFormulario.tsx
+++ b/src/app/inicio/empleador/formularioRGRL/generar/CabeceraFormulario.tsx
@@ -88,7 +88,7 @@ const CabeceraFormulario: React.FC<CabeceraFormularioProps> = ({
 					<Autocomplete
 						options={establecimientos}
 						getOptionLabel={(opt) => {
-							const suc = String(opt.nroSucursal ?? '').trim();
+							const suc = String(opt.numero ?? '').trim();
 							const calle = String(opt.domicilioCalle ?? '').trim();
 							const nro = String(opt.domicilioNro ?? '').trim();
 							const dir = [calle, nro].filter(Boolean).join(' ').trim();


### PR DESCRIPTION
Corregido los ajustes solicitados, se toma el campo correcto para el armado del combo selector:

RGRL:
<img width="1373" height="669" alt="image" src="https://github.com/user-attachments/assets/7b5deb34-dc89-483a-b3e2-1a1cf17f78b6" />

RAR:
<img width="1372" height="851" alt="image" src="https://github.com/user-attachments/assets/9541235f-380a-4aa9-809d-c49906d06c6b" />
