### PR TITLE
Feature/ajustes usuarios 060726

### DIFF
--- a/src/app/inicio/empleador/formularioRGRL/FormulariosRGRL.tsx
+++ b/src/app/inicio/empleador/formularioRGRL/FormulariosRGRL.tsx
@@ -263,15 +263,27 @@ const CargarDetalleRGRL = async (id: number): Promise<DetallePayload> => {
     NormaVigente: cat.norma,
   }));
 
-  const gremios = (data.respuestasGremio ?? []).map(g => ({
+  // Un valor identificatorio vacío, NULL o "0" indica un registro histórico incompleto que no debe mostrarse.
+  const esIdentificadorVacio = (v: unknown) => {
+    const s = String(v ?? '').trim();
+    return !s || Number(s) === 0;
+  };
+
+  const gremios = (data.respuestasGremio ?? [])
+    .filter(g => !esIdentificadorVacio(g.legajo))
+    .map(g => ({
     Legajo: String(g.legajo ?? ''),
     Nombre: g.nombre ?? ''
   }));
-  const contratistas = (data.respuestasContratista ?? []).map(c => ({
+  const contratistas = (data.respuestasContratista ?? [])
+    .filter(c => !esIdentificadorVacio(c.cuit))
+.map(c => ({
     CUIT: CUIP(c.cuit),
     Contratista: c.contratista ?? c.nombre ?? ''
   }));
-  const responsables = (data.respuestasResponsable ?? []).map(r => ({
+  const responsables = (data.respuestasResponsable ?? [])
+    .filter(r => !esIdentificadorVacio(r.cuit))
+.map(r => ({
     CUITCUIL: CUIP(r.cuit),
     NombreApellido: r.responsable ?? '',
     Cargo: normCargo(r.cargo),

--- a/src/app/inicio/usuarios/EmpresaTable.tsx
+++ b/src/app/inicio/usuarios/EmpresaTable.tsx
@@ -147,6 +147,7 @@ export default function EmpresaTable() {
 				data={tableData}
 				columns={columns}
 				isLoading={isLoading}
+				enableFiltering={false}
 				manualPagination
 				pageIndex={pageIndex}
 				pageSize={PAGE_SIZE}

--- a/src/app/inicio/usuarios/page.tsx
+++ b/src/app/inicio/usuarios/page.tsx
@@ -141,26 +141,6 @@ export default function UsuariosPage() {
   );
 
   useEffect(() => {
-    if (Number.isFinite(cuitForzado) && cuitForzado > 0) return;
-    if (isLoadingEmpresas) return;
-    if (empresas.length === 1) {
-      setEmpresaSeleccionada(empresas[0]);
-      seleccionAutomaticaRef.current = true;
-      return;
-    }
-    if (empresas.length === 0) {
-      setEmpresaSeleccionada(null);
-      seleccionAutomaticaRef.current = false;
-      return;
-    }
-    setEmpresaSeleccionada((prev) => {
-      if (!seleccionAutomaticaRef.current && prev !== null) return prev;
-      return EMPRESA_OPCION_TODAS;
-    });
-    seleccionAutomaticaRef.current = true;
-  }, [empresas, isLoadingEmpresas, cuitForzado]);
-
-  useEffect(() => {
     if (isLoadingEmpresas) return;
     const hasCuitForzado = Number.isFinite(cuitForzado) && cuitForzado > 0;
     setBloquearBusquedaPorCuit(hasCuitForzado);
@@ -174,6 +154,24 @@ export default function UsuariosPage() {
       seleccionAutomaticaRef.current = true;
     }
   }, [cuitForzado, empresas, isLoadingEmpresas]);
+
+  const empresaSeleccionadaEsValida = useMemo(() => {
+    if (empresaSeleccionada == null) return false;
+    return opcionesEmpresaSelector.some(
+      (o) => o.empresaId === empresaSeleccionada.empresaId
+    );
+  }, [empresaSeleccionada, opcionesEmpresaSelector]);
+
+  useEffect(() => {
+    if (bloquearBusquedaPorCuit) return;
+    if (isLoadingEmpresas) return;
+    if (empresas.length === 0) return;
+    if (empresaSeleccionadaEsValida) return;
+
+    if (empresas.length === 1) setEmpresaSeleccionada(empresas[0]);
+    else setEmpresaSeleccionada(EMPRESA_OPCION_TODAS);
+    seleccionAutomaticaRef.current = true;
+  }, [bloquearBusquedaPorCuit, isLoadingEmpresas, empresas, empresaSeleccionadaEsValida]);
 
   const handleEmpresaChange = (_event: React.SyntheticEvent, newValue: Empresa | null) => {
     if (bloquearBusquedaPorCuit) return;


### PR DESCRIPTION
1- Se corrigió el comportamiento del Selector de Empresas para impedir que el filtro quede vacío al eliminar la selección. El componente garantiza que siempre exista un valor seleccionado (empresa o "Todas las Empresas"), resolviendo el inconveniente detectado en Configuración de Filtros.

2 - Se eliminó el filtro "Buscar en la tabla" de la solapa Configuración de Empresa, conforme a lo solicitado.

--------------------------------

Se realizaron los siguientes ajustes:

Se incorporó un filtro para la sección Gremios, excluyendo aquellos registros cuyo Número de Legajo se encuentre con valor 0, NULL o vacío.

Se aplicó el mismo criterio para la sección Contratistas, ocultando los registros cuyo CUIT/CUIL sea 0, NULL o vacío.

Se implementó la misma validación para la sección Responsables, evitando mostrar registros con CUIT/CUIL 0, NULL o vacío.

El criterio de filtrado fue aplicado tanto en la visualización del formulario dentro de ART Gestión como en la generación e impresión del PDF, garantizando consistencia entre ambas vistas.

Con estos cambios, los registros históricos que fueron generados en el sistema anterior con información incompleta dejan de visualizarse, mostrando únicamente datos válidos y relevantes para el usuario.

<img width="3894" height="925" alt="image" src="https://github.com/user-attachments/assets/26dd34c7-b1bd-4f83-bb1c-954a8967fcef" />
