### PR TITLE
Feature/ajustes cobertura 080726

### DIFF
--- a/src/app/inicio/denuncias/types/tDenuncias.tsx
+++ b/src/app/inicio/denuncias/types/tDenuncias.tsx
@@ -849,5 +849,5 @@ export type ParametersEmpleadorT = {
   CUIL?: number;
   PageIndex?: number;
   PageSize?: number;
-  Perido?: number;
+  Periodos?: number;
 };

--- a/src/app/inicio/denuncias/types/tDenuncias.tsx
+++ b/src/app/inicio/denuncias/types/tDenuncias.tsx
@@ -849,5 +849,5 @@ export type ParametersEmpleadorT = {
   CUIL?: number;
   PageIndex?: number;
   PageSize?: number;
-  Periodos?: number;
+  Periodos?: number[];
 };

--- a/src/app/inicio/empleador/cobertura/page.tsx
+++ b/src/app/inicio/empleador/cobertura/page.tsx
@@ -27,7 +27,7 @@ import dayjs from "dayjs";
 
 const { useGetPoliza } = SrtAPI;
 
-const getPeriodo = (): string => dayjs().subtract(2, "month").format("YYYYMM");
+const getPeriodos = (): number[] => Array.from({ length: 3 }, (_, i) => Number(dayjs().subtract(i, "month").format("YYYYMM")));
 
 export default function CoberturaPage() {
     const { user } = useAuth();
@@ -209,7 +209,7 @@ export default function CoberturaPage() {
         (async () => {
             try {
                 setIsPersonalLoading(true);
-                const raw = await ArtAPI.getEmpleadorTrabajadores({ CUIL: cuilToQuery, PageSize: 99999, Periodos: Number(getPeriodo()) });
+                const raw = await ArtAPI.getEmpleadorTrabajadores({ CUIL: cuilToQuery, PageSize: 99999, Periodos: getPeriodos() });
                 const arr = Array.isArray(raw) ? raw : (raw?.DATA ?? raw?.data ?? []);
                 const personas: Persona[] = (arr as unknown[])
                     .map((x) => {

--- a/src/app/inicio/empleador/cobertura/page.tsx
+++ b/src/app/inicio/empleador/cobertura/page.tsx
@@ -209,7 +209,7 @@ export default function CoberturaPage() {
         (async () => {
             try {
                 setIsPersonalLoading(true);
-                const raw = await ArtAPI.getEmpleadorTrabajadores({ CUIL: cuilToQuery, PageSize: 99999, Perido: Number(getPeriodo()) });
+                const raw = await ArtAPI.getEmpleadorTrabajadores({ CUIL: cuilToQuery, PageSize: 99999, Periodos: Number(getPeriodo()) });
                 const arr = Array.isArray(raw) ? raw : (raw?.DATA ?? raw?.data ?? []);
                 const personas: Persona[] = (arr as unknown[])
                     .map((x) => {

--- a/src/app/inicio/empleador/credenciales/page.tsx
+++ b/src/app/inicio/empleador/credenciales/page.tsx
@@ -69,7 +69,7 @@ function CredencialesPage() {
           CUIL: selectedEmpresaCUIT,
           PageIndex,
           PageSize,
-          Perido: Number(getPeriodo()),
+          Periodos: Number(getPeriodo()),
         });
 
         if (canceled) return;

--- a/src/app/inicio/empleador/credenciales/page.tsx
+++ b/src/app/inicio/empleador/credenciales/page.tsx
@@ -21,7 +21,7 @@ import dayjs from "dayjs";
 import { TextField } from '@mui/material';
 import { applySRTPolizasVerIndependientes } from '@/utils/srtPolizasParams';
 
-const getPeriodo = (): string => dayjs().subtract(2, "month").format("YYYYMM");
+const getPeriodos = (): number[] => Array.from({ length: 3 }, (_, i) => Number(dayjs().subtract(i, "month").format("YYYYMM")));
 
 function CredencialesPage() {
   const { user } = useAuth();
@@ -69,7 +69,7 @@ function CredencialesPage() {
           CUIL: selectedEmpresaCUIT,
           PageIndex,
           PageSize,
-          Periodos: Number(getPeriodo()),
+          Periodos: getPeriodos(),
         });
 
         if (canceled) return;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -72,6 +72,7 @@ export function toURLSearch(o: any, execute = false): URLSearchParams | undefine
     }
   }
   function load(k: string, v: any) {
+    if (Array.isArray(v)) return v.forEach(item => load(k, item));
     v = value(v);
     if (v === undefined) return;
     s.append(k, v);


### PR DESCRIPTION
Se adecuó la búsqueda de trabajadores en los módulos Cobertura y Credenciales para que ya no consulte únicamente un período específico, sino que contemple el período actual y los dos meses anteriores.

De esta manera, si un trabajador no posee información en uno de los períodos pero sí en cualquiera de los otros comprendidos dentro del rango, igualmente será mostrado en la consulta.

Con este cambio se evita que trabajadores con información vigente en meses recientes queden excluidos de la búsqueda.

Se tuvo en cuenta que NO se muestren el mismo trabajador dos veces si aparece en mas de un periodo