### PR TITLE
Feat: tarea para habilitar filtros comercializador/cuentaCorrinete

### DIFF
--- a/src/app/inicio/comercializador/cuentaCorriente/page.tsx
+++ b/src/app/inicio/comercializador/cuentaCorriente/page.tsx
@@ -36,7 +36,7 @@ function digits(value: unknown) {
 }
 
 function CuentaCorrienteComercializador() {
-    const { user } = useAuth();
+    const { user, hasTask } = useAuth();
 
     const rol = String((user as any)?.rol ?? '').toLowerCase();
     const cuil = Number(digits((user as any)?.cuit ?? (user as any)?.CUIL ?? (user as any)?.cuil ?? 0));
@@ -47,7 +47,8 @@ function CuentaCorrienteComercializador() {
     const isGrupoOrganizador = rol === 'grupoorganizador';
     const isOrganizadorComercializador = rol === 'organizadorcomercializador';
     const isComercializador = rol === 'comercializador';
-    const isAdminLevel = isAdmin || isAdminComercializador || isAdministradorART;
+    const isAdminLevel = isAdmin || isAdminComercializador || isAdministradorART
+        || hasTask('Comercializador_CuentaCorriente_VerTodosLosFiltros');
 
     const [grupo, setGrupo] = useState<any>(null);
     const [organizador, setOrganizador] = useState<any>(null);


### PR DESCRIPTION
Se implementó la habilitación de los filtros globales de Empresa, Grupo, Organizador y Comercializador para usuarios específicos del módulo Comercializador.

Comercializador → Cuenta Corriente
Se creó la nueva tarea Comercializador_CuentaCorriente_VerTodosLosFiltros.