### PR TITLE
Feat: manejo por tarea administracion de comercializadores

### DIFF
--- a/src/app/inicio/comercializador/administracionComercializadores/page.tsx
+++ b/src/app/inicio/comercializador/administracionComercializadores/page.tsx
@@ -73,11 +73,8 @@ export default function AdminUserPage() {
 
   const isGrupoOrganizador = String((user as any)?.rol ?? '').toLowerCase() === 'grupoorganizador';
   const isOrganizadorComercializador = String((user as any)?.rol ?? '').toLowerCase() === 'organizadorcomercializador';
-  const isAdministrador = String((user as any)?.rol ?? '').toLowerCase() === 'administrador' || String((user as any)?.rol ?? '').toLowerCase() === 'administradorart';
-  const isAdminComercializador = String((user as any)?.rol ?? '').toLowerCase() === 'administradorcomercializador';
-  const isAdministradorART = String((user as any)?.rol ?? '').toLowerCase() === 'administradorart';
   const isComercializador = String((user as any)?.rol ?? '').toLowerCase() === 'comercializador';
-  const isAdminLevel = isAdministrador || isAdminComercializador || isAdministradorART;
+  const isAdminLevel = hasTask('Comercializador_Administracion_VerUsuarios');
   const canLoadComercializadores = isGrupoOrganizador || isOrganizadorComercializador || isAdminLevel;
   const userCuit = Number(digits((user as any)?.cuit ?? (user as any)?.CUIL ?? (user as any)?.cuil ?? 0));
   const userCuitValid = Number.isFinite(userCuit) && userCuit > 0 ? userCuit : undefined;
@@ -150,13 +147,12 @@ export default function AdminUserPage() {
   const isLoadingGrupoTable = isOrganizadorComercializador ? isLoadingGOrgById : isLoadingGOrg;
 
   const comercializadorParams = selectedOrganizadorInterno !== undefined
-    ? ({ SRTComercializadorOrganizadorInterno: selectedOrganizadorInterno } as any)
+    ? ({ SRTComercializadorOrganizadorInterno: selectedOrganizadorInterno, ComercializadoresOrganizadoresInternos: String(selectedOrganizadorInterno) } as any)
     : ({} as any);
 
-  const { data: comercializadorData, isLoading: isLoadingComercializador, mutate: mutateComercializador } =
-    ArtAPI.useGetComercializadorUsuarioLogueadoURL(
-      canLoadComercializadores ? comercializadorParams : null
-    );
+  const usuarioLogueadoResult = ArtAPI.useGetComercializadorUsuarioLogueadoURL(canLoadComercializadores && !isAdminLevel ? comercializadorParams : null);
+  const todosResult = ArtAPI.useGetComercializadorURL(isAdminLevel ? comercializadorParams : null);
+  const { data: comercializadorData, isLoading: isLoadingComercializador, mutate: mutateComercializador } = isAdminLevel ? todosResult : usuarioLogueadoResult;
 
   const grupoRows: ComercializadoresGOrganizadoresRow[] = useMemo(() => {
     if (!isGrupoOrganizador && !isAdminLevel && !isOrganizadorComercializador) return [];


### PR DESCRIPTION
Se realizaron mejoras en el módulo Comercializador > Administración para que el acceso a la información se gestione mediante el sistema de permisos, en lugar de depender de una lista fija de roles.

Situación detectada

La visualización de las tablas de Grupos, Organizadores y Comercializadores estaba condicionada a determinados roles definidos en el código de la aplicación. Como consecuencia, usuarios con otros perfiles (por ejemplo, Finanzas) no podían visualizar la información, aun cuando contaban con los permisos correspondientes.

Cambios realizados

Se incorporó el permiso Comercializador_Administracion_VerUsuarios como criterio para habilitar el acceso a la pantalla, reemplazando la validación basada exclusivamente en roles.
Se ajustó la carga de información para que los usuarios con este permiso puedan visualizar el listado completo de comercializadores.
Para el resto de los usuarios, se mantiene el comportamiento actual, mostrando únicamente la información asociada a su perfil.
Los cambios realizados mantienen la compatibilidad con los perfiles administrativos existentes.