### PR TITLE
Feat: se le agrega cuit al selector de empresa

### DIFF
--- a/src/app/inicio/empleador/credenciales/Credenciales.module.css
+++ b/src/app/inicio/empleador/credenciales/Credenciales.module.css
@@ -97,10 +97,12 @@
   flex-direction: column;
   gap: 8px;
   align-items: flex-start;
+  width: 100%;
 }
 
 .selectWrap {
-  min-width: 300px;
+  width: 100%;
+  max-width: 500px;
 }
 
 .actionsRow {

--- a/src/app/inicio/empleador/credenciales/page.tsx
+++ b/src/app/inicio/empleador/credenciales/page.tsx
@@ -208,7 +208,7 @@ function CredencialesPage() {
           <div className={styles.selectWrap}>
             <CustomSelectSearch<Empresa>
               options={empresas}
-              getOptionLabel={(e) => e ? String(e.razonSocial) : ''}
+              getOptionLabel={(e) => e ? `${e.razonSocial ?? ""} - ${Formato.CUIP(e.cuit)}` : ''}
               value={empresaSeleccionada}
               onChange={(_ev, newVal) => setEmpresaSeleccionada(newVal)}
               label="Seleccionar Empresa"


### PR DESCRIPTION
Resumen para la tarjeta:

Se corrigió el selector de empresa del módulo /empleador/credenciales

Se agregó el CUIL al selector de empresa: el combo ahora muestra Razón Social - CUIL (formateado con máscara ##-########-#), igual que en cobertura, en vez de mostrar solo la razón social.

Se ajustó el ancho del selector: el combo se veía muy chico porque se achicaba al contenido; ahora ocupa el mismo ancho que el de cobertura (max-width: 500px, ancho completo del contenedor).
