### PR TITLE
Feature/ajustes 130826

### DIFF
--- a/src/app/inicio/empleador/formularioRGRL/generar/CabeceraFormulario.tsx
+++ b/src/app/inicio/empleador/formularioRGRL/generar/CabeceraFormulario.tsx
@@ -84,7 +84,7 @@ const CabeceraFormulario: React.FC<CabeceraFormularioProps> = ({
 				/>
 			</Box>
 			<Box className={styles.establecimientoBox}>
-				<FormControl fullWidth disabled={esReplica || soloLectura} title={esReplica ? 'Tipo fijado por replicación' : undefined}>
+				<FormControl fullWidth disabled={soloLectura}>
 					<Autocomplete
 						options={establecimientos}
 						getOptionLabel={(opt) => {
@@ -98,7 +98,7 @@ const CabeceraFormulario: React.FC<CabeceraFormularioProps> = ({
 						onChange={(_e, newVal) => onEstablecimientoChange(newVal ? newVal.interno : undefined)}
 						isOptionEqualToValue={(option, value) => option.interno === value.interno}
 						renderInput={(params) => <TextField {...params} label="Establecimiento" />}
-						disabled={esReplica || soloLectura}
+						disabled={soloLectura}
 					/>
 				</FormControl>
 			</Box>

--- a/src/app/inicio/empleador/formularioRGRL/generar/GenerarFormularioRGRL.tsx
+++ b/src/app/inicio/empleador/formularioRGRL/generar/GenerarFormularioRGRL.tsx
@@ -394,7 +394,10 @@ const GenerarFormularioRGRL: React.FC<{
           renglon: i,
         }));
 
-        const responsablesFull = (original.respuestasResponsable || []).map((r: any, i: number) => ({
+        const cambioEstablecimiento = establecimientoSel !== original.internoEstablecimiento;
+        const responsablesFull = cambioEstablecimiento
+          ? []
+          : (original.respuestasResponsable || []).map((r: any, i: number) => ({
           interno: 0,
           internoRespuestaFormulario: nuevoId,
           cuit: r?.cuit ?? 0,

--- a/src/app/inicio/empleador/formularioRGRL/generar/GenerarFormularioRGRL.tsx
+++ b/src/app/inicio/empleador/formularioRGRL/generar/GenerarFormularioRGRL.tsx
@@ -866,7 +866,7 @@ const GenerarFormularioRGRL: React.FC<{
           setModalMsgOpen(true);
           return;
         }
-        if (typeof r.representacion !== 'number') {
+        if (typeof r.representacion !== 'number' || r.representacion === 0) {
           setError('');
           setModalMsg(`En Responsables, la fila ${i + 1} requiere completar Representación.`);
           setModalMsgType('error');
@@ -885,7 +885,7 @@ const GenerarFormularioRGRL: React.FC<{
 
     if (completar) {
       // Requerir al menos un Responsable de Datos del Formulario con datos completos
-      const tieneRespDatos = responsablesUI.some(r => r.cargo === 'R' && (r.cuit ?? '') && (r.responsable ?? '').toString().trim() !== '' && typeof r.representacion === 'number' && typeof r.esContratado === 'number');
+      const tieneRespDatos = responsablesUI.some(r => r.cargo === 'R' && (r.cuit ?? '') && (r.responsable ?? '').toString().trim() !== '' && typeof r.representacion === 'number' && r.representacion !== 0 && typeof r.esContratado === 'number');
       if (!tieneRespDatos) {
         setError('');
         setModalMsg('Debe indicar al menos un Responsable de Datos del Formulario con CUIT, nombre, representación y Propio/Contratado.');
@@ -1000,7 +1000,7 @@ const GenerarFormularioRGRL: React.FC<{
         cuit: Number(r.cuit ?? 0),
         responsable: r.responsable ?? '',
         cargo: r.cargo ?? '',
-        representacion: Number(r.representacion ?? 0),
+        representacion: Number(r.representacion),
         esContratado: Number(r.esContratado ?? 0),
         tituloHabilitante: r.tituloHabilitante ?? '',
         matricula: r.matricula ?? '',
@@ -1444,11 +1444,11 @@ const GenerarFormularioRGRL: React.FC<{
                       <MenuItem value=""><em>Seleccioná...</em></MenuItem>
                       <MenuItem value={1}>Representante Legal</MenuItem>
                       <MenuItem value={2}>Presidente</MenuItem>
-                      <MenuItem value={3}>VicePresidente</MenuItem>
-                      <MenuItem value={4}>Director General</MenuItem>
-                      <MenuItem value={5}>Gerente General</MenuItem>
-                      <MenuItem value={6}>Administrador General</MenuItem>
-                      <MenuItem value={0}>Otros</MenuItem>
+                      <MenuItem value={3}>Director General</MenuItem>
+                      <MenuItem value={4}>Administrador General</MenuItem>
+                      <MenuItem value={5}>Vicepresidente</MenuItem>
+                      <MenuItem value={6}>Gerente General</MenuItem>
+                      <MenuItem value={99}>Otros</MenuItem>
                     </Select>
                   </FormControl>
                   <FormControl fullWidth>

--- a/src/utils/excelUtils.ts
+++ b/src/utils/excelUtils.ts
@@ -379,7 +379,7 @@ export async function importarTrabajadoresDesdeExcel(file: File, maxTrabajadores
     if (validacionInicio.valida && validacionIngreso.valida && validacionInicio.fecha < validacionIngreso.fecha) {
       erroresFila.push('La fecha inicio exposición debe ser mayor o igual a la fecha de ingreso');
     }
-    if (validacionExamen.valida && validacionIngreso.valida && validacionExamen.fecha <= validacionIngreso.fecha) {
+    if (validacionExamen.valida && validacionIngreso.valida && validacionExamen.fecha < validacionIngreso.fecha) {
       erroresFila.push('La fecha del último examen médico debe ser posterior a la fecha de ingreso');
     }
     if (fechaFinExposicionValidada && validacionInicio.valida && fechaFinExposicionValidada < validacionInicio.fecha) {


### PR DESCRIPTION
# 📝 Formularios RAR y RGRL

## 📋 Formulario RAR
- Ajuste de la validación de fechas en la importación de trabajadores desde Excel.
- Se permite que la **Fecha del Último Examen Médico** sea igual a la **Fecha de Ingreso**.
- Solo se rechazan registros cuando el examen médico es anterior a la fecha de ingreso.

## 🏢 Formulario RGRL
- Se incorporó la posibilidad de seleccionar cualquier **establecimiento activo del empleador** al replicar un formulario.
- El tipo de formulario se mantiene fijo durante la réplica.
- Los responsables se conservan al replicar sobre el mismo establecimiento y se limpian al seleccionar uno diferente.
- Se mantienen los datos propios del establecimiento seleccionado, como **superficie y cantidad de trabajadores**.

## ✅ Resultado
Se ajustó la validación de importación del RAR y se amplió la réplica del RGRL para permitir seleccionar distintos establecimientos del mismo empleador, respetando la información específica de cada uno.